### PR TITLE
fix: Refine State and Session Model

### DIFF
--- a/pkg/session/model.go
+++ b/pkg/session/model.go
@@ -2,19 +2,26 @@ package session
 
 import "time"
 
-type Session struct {
-	ID          string
-	TenantID    string
-	Fingerprint string
-	Token       string
-	Expiry      time.Time
+// State represents the state of an authentication process according to the OIDC spec.
+// It is used to align the auth request with the callback and to store necessary
+// information for completing the authentication process.
+type State struct {
+	ID           string    // State ID to align the auth request with the callback
+	TenantID     string    // Tenant ID for which the login is done
+	Fingerprint  string    // Fingerprint to bind the login to a specific client
+	PKCEVerifier string    // PKCE verifier to validate the PKCE challenge
+	RequestURI   string    // Request URI for the eventual redirect
+	Expiry       time.Time // Expiry time of the login process
 }
 
-type State struct {
-	ID           string
-	TenantID     string
-	Fingerprint  string
-	PKCEVerifier string
-	RequestURI   string
-	Expiry       time.Time
+// Session represents a user session in our system.
+type Session struct {
+	ID           string    // Session ID in our system
+	TenantID     string    // Tenant ID for which the session is created
+	Fingerprint  string    // Fingerprint to bind the session to a specific client
+	CSRFToken    string    // CSRF token to prevent CSRF attacks
+	Claims       string    // JSON string of claims from the ID token
+	AccessToken  string    // Access token from the identity provider
+	RefreshToken string    // Refresh token from the identity provider
+	Expiry       time.Time // Expiry time of the session
 }

--- a/pkg/session/valkey/repository_test.go
+++ b/pkg/session/valkey/repository_test.go
@@ -178,11 +178,12 @@ func TestRepository_StoreState(t *testing.T) {
 
 func TestRepository_LoadSession(t *testing.T) {
 	prepareSession(t, session.Session{
-		ID:          "sessionid-one",
-		TenantID:    "tenant1-id",
-		Fingerprint: "fingerprint-one",
-		Token:       "token-one",
-		Expiry:      testTime,
+		ID:           "sessionid-one",
+		TenantID:     "tenant1-id",
+		Fingerprint:  "fingerprint-one",
+		AccessToken:  "access-token-one",
+		RefreshToken: "refresh-token-one",
+		Expiry:       testTime,
 	})
 
 	tests := []struct {
@@ -197,11 +198,12 @@ func TestRepository_LoadSession(t *testing.T) {
 			tenantID:  "tenant1-id",
 			sessionID: "sessionid-one",
 			wantSession: session.Session{
-				ID:          "sessionid-one",
-				TenantID:    "tenant1-id",
-				Fingerprint: "fingerprint-one",
-				Token:       "token-one",
-				Expiry:      testTime,
+				ID:           "sessionid-one",
+				TenantID:     "tenant1-id",
+				Fingerprint:  "fingerprint-one",
+				AccessToken:  "access-token-one",
+				RefreshToken: "refresh-token-one",
+				Expiry:       testTime,
 			},
 			assertErr: assert.NoError,
 		},
@@ -229,11 +231,12 @@ func TestRepository_LoadSession(t *testing.T) {
 func TestRepository_StoreSession(t *testing.T) {
 	const upsertTenantID = "tenant-id-upsert"
 	upsertSession := session.Session{
-		ID:          "sessionid-to-upsert",
-		TenantID:    upsertTenantID,
-		Fingerprint: "fingerprint-upsert",
-		Token:       "token-upsert",
-		Expiry:      testTime,
+		ID:           "sessionid-to-upsert",
+		TenantID:     upsertTenantID,
+		Fingerprint:  "fingerprint-upsert",
+		AccessToken:  "access-token-upsert",
+		RefreshToken: "refresh-token-upsert",
+		Expiry:       testTime,
 	}
 
 	prepareSession(t, upsertSession)
@@ -248,11 +251,12 @@ func TestRepository_StoreSession(t *testing.T) {
 			name:     "Success",
 			tenantID: "tenant-id-store-session-success",
 			session: session.Session{
-				ID:          "sessionid-id-store-session-success",
-				TenantID:    "tenant-id-store-session-success",
-				Fingerprint: "fingerprint-one",
-				Token:       "token-one",
-				Expiry:      testTime,
+				ID:           "sessionid-id-store-session-success",
+				TenantID:     "tenant-id-store-session-success",
+				Fingerprint:  "fingerprint-one",
+				AccessToken:  "access-token-one",
+				RefreshToken: "refresh-token-one",
+				Expiry:       testTime,
 			},
 			assertErr: assert.NoError,
 		},
@@ -260,11 +264,12 @@ func TestRepository_StoreSession(t *testing.T) {
 			name:     "Upsert successfully",
 			tenantID: upsertTenantID,
 			session: session.Session{
-				ID:          upsertSession.ID,
-				TenantID:    upsertSession.TenantID,
-				Fingerprint: "fingerprint-upsert-new",
-				Token:       "token-upsert-new",
-				Expiry:      testTime,
+				ID:           upsertSession.ID,
+				TenantID:     upsertSession.TenantID,
+				Fingerprint:  "fingerprint-upsert-new",
+				AccessToken:  "access-token-upsert-new",
+				RefreshToken: "refresh-token-upsert-new",
+				Expiry:       testTime,
 			},
 			assertErr: assert.NoError,
 		},


### PR DESCRIPTION
Document both structures `State` and `Session`.

Replace the `Token` field with:

- the `Claims` from the ID token (we don't store the whole ID token for security reasons)
- the `AccessToken`
- the `RefreshToken`

Also add the `CSRFToken` field.