### PR TITLE
fix: Logout for the right tenant session

### DIFF
--- a/api/session-manager.yaml
+++ b/api/session-manager.yaml
@@ -1,4 +1,4 @@
-openapi: 3.1.1
+openapi: 3.0.4
 info:
     title: Session Manager
     description:
@@ -63,6 +63,11 @@ paths:
 
                 This allows the CMK UI to iniate the SLO.
             parameters:
+                - name: tenant_id
+                  in: query
+                  required: true
+                  schema:
+                      type: string
                 - name: "Cookie"
                   in: header
                   required: true

--- a/internal/business/server/openapi.go
+++ b/internal/business/server/openapi.go
@@ -38,8 +38,8 @@ type openAPIServer struct {
 
 	csrfSecret []byte
 
-	sessionIDCookieName,
-	csrfTokenCookieName string
+	sessionIDCookieNamePrefix string
+	csrfTokenCookieNamePrefix string
 }
 
 // Ensure openAPIServer implements [openapi.StrictServerInterface]
@@ -49,14 +49,14 @@ var _ openapi.StrictServerInterface = (*openAPIServer)(nil)
 func newOpenAPIServer(
 	sManager sessionManager,
 	csrfSecret []byte,
-	sessionIDCookieName,
-	csrfTokenCookieName string,
+	sessionIDCookieNamePrefix,
+	csrfTokenCookieNamePrefix string,
 ) *openAPIServer {
 	return &openAPIServer{
-		sManager:            sManager,
-		csrfSecret:          csrfSecret,
-		sessionIDCookieName: sessionIDCookieName,
-		csrfTokenCookieName: csrfTokenCookieName,
+		sManager:                  sManager,
+		csrfSecret:                csrfSecret,
+		sessionIDCookieNamePrefix: sessionIDCookieNamePrefix,
+		csrfTokenCookieNamePrefix: csrfTokenCookieNamePrefix,
 	}
 }
 
@@ -228,7 +228,7 @@ func (s *openAPIServer) Logout(ctx context.Context, request openapi.LogoutReques
 	ctx, span := tracer.Tracer("").Start(ctx, "logout")
 	defer span.End()
 
-	slogctx.Debug(ctx, "Logout() called")
+	slogctx.Debug(ctx, "Logout() called", "tenantId", request.Params.TenantID)
 	defer slogctx.Debug(ctx, "Logout() completed")
 
 	rw, err := middleware.ResponseWriterFromContext(ctx)
@@ -257,6 +257,8 @@ func (s *openAPIServer) Logout(ctx context.Context, request openapi.LogoutReques
 		}, nil
 	}
 
+	sessionCookieName := s.sessionIDCookieNamePrefix + "-" + request.Params.TenantID
+	csrfCookieName := s.csrfTokenCookieNamePrefix + "-" + request.Params.TenantID
 	var sessionCookie *http.Cookie
 	var csrfCookie *http.Cookie
 
@@ -265,9 +267,9 @@ func (s *openAPIServer) Logout(ctx context.Context, request openapi.LogoutReques
 	// so we can safely iterate over the cookies.
 	for _, cookie := range cookies {
 		switch cookie.Name {
-		case s.csrfTokenCookieName:
+		case csrfCookieName:
 			csrfCookie = cookie
-		case s.sessionIDCookieName:
+		case sessionCookieName:
 			sessionCookie = cookie
 		}
 
@@ -278,6 +280,7 @@ func (s *openAPIServer) Logout(ctx context.Context, request openapi.LogoutReques
 
 	if sessionCookie == nil || sessionCookie.Value == "" {
 		body, status := newBadRequest("missing session id in the cookies")
+		slogctx.Warn(ctx, "missing session id in the cookies")
 		return openapi.LogoutdefaultJSONResponse{
 			Body:       body,
 			StatusCode: status,
@@ -286,6 +289,7 @@ func (s *openAPIServer) Logout(ctx context.Context, request openapi.LogoutReques
 
 	if csrfCookie == nil || csrfCookie.Value == "" {
 		body, status := newBadRequest("missing csrf token in the cookies")
+		slogctx.Warn(ctx, "missing csrf token in the cookies")
 		return openapi.LogoutdefaultJSONResponse{
 			Body:       body,
 			StatusCode: status,

--- a/internal/business/server/openapi_test.go
+++ b/internal/business/server/openapi_test.go
@@ -89,8 +89,8 @@ func TestNewOpenAPIServer(t *testing.T) {
 
 		assert.NotNil(t, server)
 		assert.Equal(t, csrfSecret, server.csrfSecret)
-		assert.Equal(t, sessionCookieName, server.sessionIDCookieName)
-		assert.Equal(t, csrfCookieName, server.csrfTokenCookieName)
+		assert.Equal(t, sessionCookieName, server.sessionIDCookieNamePrefix)
+		assert.Equal(t, csrfCookieName, server.csrfTokenCookieNamePrefix)
 	})
 }
 
@@ -549,6 +549,7 @@ func TestOpenAPIServer_Logout_MissingSessionCookie(t *testing.T) {
 
 func TestOpenAPIServer_Logout_MissingCSRFCookie(t *testing.T) {
 	t.Run("returns an error when CSRF cookie is missing", func(t *testing.T) {
+		const tenantID = "tenant-1"
 		server := newOpenAPIServer(nil, []byte("secret"), "session-id", "csrf-token")
 
 		rw := httptest.NewRecorder()
@@ -556,7 +557,8 @@ func TestOpenAPIServer_Logout_MissingCSRFCookie(t *testing.T) {
 
 		logoutReq := openapi.LogoutRequestObject{
 			Params: openapi.LogoutParams{
-				Cookie:     "session-id=session-123",
+				TenantID:   tenantID,
+				Cookie:     "session-id-" + tenantID + "=session-123",
 				XCSRFToken: "some-token",
 			},
 		}
@@ -576,6 +578,7 @@ func TestOpenAPIServer_Logout_MissingCSRFCookie(t *testing.T) {
 
 func TestOpenAPIServer_Logout_InvalidCSRFToken(t *testing.T) {
 	t.Run("returns an error when CSRF token is invalid", func(t *testing.T) {
+		const tenantID = "tenant-1"
 		server := newOpenAPIServer(nil, []byte("test-secret-32-bytes-length!!"), "session-id", "csrf-token")
 
 		rw := httptest.NewRecorder()
@@ -583,7 +586,8 @@ func TestOpenAPIServer_Logout_InvalidCSRFToken(t *testing.T) {
 
 		logoutReq := openapi.LogoutRequestObject{
 			Params: openapi.LogoutParams{
-				Cookie:     "session-id=session-123; csrf-token=csrf-123",
+				TenantID:   tenantID,
+				Cookie:     "session-id-" + tenantID + "=session-123; csrf-token-" + tenantID + "=csrf-123",
 				XCSRFToken: "wrong-csrf-token",
 			},
 		}
@@ -603,6 +607,7 @@ func TestOpenAPIServer_Logout_InvalidCSRFToken(t *testing.T) {
 func TestOpenAPIServer_Logout_Failed(t *testing.T) {
 	t.Run("returns an error Logout failed", func(t *testing.T) {
 		const tokenKey = "test-secret-32-bytes-length!!"
+		const tenantID = "tenant-1"
 		mock := &mockSessionManager{
 			logoutFunc: func(ctx context.Context, sessionID string) (string, error) {
 				return "", errors.New("error")
@@ -617,7 +622,8 @@ func TestOpenAPIServer_Logout_Failed(t *testing.T) {
 		token := csrf.NewToken("session-123", []byte(tokenKey))
 		logoutReq := openapi.LogoutRequestObject{
 			Params: openapi.LogoutParams{
-				Cookie:     "session-id=session-123; csrf-token=" + token,
+				TenantID:   tenantID,
+				Cookie:     "session-id-" + tenantID + "=session-123; csrf-token-" + tenantID + "=" + token,
 				XCSRFToken: token,
 			},
 		}
@@ -769,6 +775,7 @@ func TestOpenAPIServer_Logout_Success(t *testing.T) {
 		expectedURL := "https://idp.example.com/logout"
 		csrfSecret := []byte("secret-key-12345")
 		sessionID := "session-123"
+		tenantID := "tenant-1"
 
 		// Generate a valid CSRF token
 		validCSRFToken := csrf.NewToken(sessionID, csrfSecret)
@@ -786,7 +793,8 @@ func TestOpenAPIServer_Logout_Success(t *testing.T) {
 
 		logoutReq := openapi.LogoutRequestObject{
 			Params: openapi.LogoutParams{
-				Cookie:     "session-id=" + sessionID + "; csrf-token=" + validCSRFToken,
+				TenantID:   tenantID,
+				Cookie:     "session-id-" + tenantID + "=" + sessionID + "; csrf-token-" + tenantID + "=" + validCSRFToken,
 				XCSRFToken: validCSRFToken,
 			},
 		}

--- a/internal/openapi/server.go
+++ b/internal/openapi/server.go
@@ -42,6 +42,7 @@ type CallbackParams struct {
 
 // LogoutParams defines parameters for Logout.
 type LogoutParams struct {
+	TenantID   string `form:"tenant_id" json:"tenant_id"`
 	Cookie     string `json:"Cookie"`
 	XCSRFToken string `json:"X-CSRF-Token"`
 }
@@ -211,6 +212,21 @@ func (siw *ServerInterfaceWrapper) Logout(w http.ResponseWriter, r *http.Request
 
 	// Parameter object where we will unmarshal all parameters from the context
 	var params LogoutParams
+
+	// ------------- Required query parameter "tenant_id" -------------
+
+	if paramValue := r.URL.Query().Get("tenant_id"); paramValue != "" {
+
+	} else {
+		siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "tenant_id"})
+		return
+	}
+
+	err = runtime.BindQueryParameter("form", true, true, "tenant_id", r.URL.Query(), &params.TenantID)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "tenant_id", Err: err})
+		return
+	}
 
 	headers := r.Header
 


### PR DESCRIPTION
When the UI calls the `/sm/logout` endpoint the session manager does not really know which tenant to log out from, as there can be many cookies, which may be related to several IDPs. I guess this is because some months ago we switched from single cookies to named cookies but did not adjust the SLO part. Therefore, the UI should send the session manager the tenant id like this: `/sm/logout?tenant_id=...`. Then the session manager can call the end session endpoint of the IDP, which will trigger the back channel logout for all other related sessions.

PS: also lower the openapi spec version because oapi-codegen does not yet support the newest.