### PR TITLE
fix: switch in-memory cache implementation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,11 +18,11 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/jackc/pgx/v5 v5.9.1
+	github.com/jellydator/ttlcache/v3 v3.4.0
 	github.com/moby/moby/api v1.54.1
 	github.com/oapi-codegen/runtime v1.4.0
 	github.com/openkcm/api-sdk v0.17.0
 	github.com/openkcm/common-sdk v1.15.2
-	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/pressly/goose/v3 v3.27.0
 	github.com/samber/oops v1.21.0
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -154,6 +154,8 @@ github.com/jackc/pgx/v5 v5.9.1 h1:uwrxJXBnx76nyISkhr33kQLlUqjv7et7b9FjCen/tdc=
 github.com/jackc/pgx/v5 v5.9.1/go.mod h1:mal1tBGAFfLHvZzaYh77YS/eC6IX9OWbRV1QIIM0Jn4=
 github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo=
 github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
+github.com/jellydator/ttlcache/v3 v3.4.0 h1:YS4P125qQS0tNhtL6aeYkheEaB/m8HCqdMMP4mnWdTY=
+github.com/jellydator/ttlcache/v3 v3.4.0/go.mod h1:Hw9EgjymziQD3yGsQdf1FqFdpp7YjFMd4Srg5EJlgD4=
 github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD/E=
 github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
@@ -252,8 +254,6 @@ github.com/openkcm/api-sdk v0.17.0 h1:AwDrJvaEj6f35JAohwzILU3nMTeD19J3ycebq0weOM
 github.com/openkcm/api-sdk v0.17.0/go.mod h1:ffjao8Qr0k9FbtYWmPWWHf52tfBec2CRN4IBgj+ncqo=
 github.com/openkcm/common-sdk v1.15.2 h1:bvY/wYTxreuqEiMaJtHIgffOPL8oqADIt34yixSe5Sg=
 github.com/openkcm/common-sdk v1.15.2/go.mod h1:K/7chyp7s9w8VZO7edy3+FI+lJ6ii0u7qfm8xD68ap0=
-github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
-github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/pborman/getopt v0.0.0-20170112200414-7148bc3a4c30/go.mod h1:85jBQOZwpVEaDAr341tbn15RS4fCAsIst0qp7i8ex1o=
 github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=
 github.com/pelletier/go-toml/v2 v2.2.4/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=

--- a/integration/grpc_test.go
+++ b/integration/grpc_test.go
@@ -327,7 +327,7 @@ func startServer(t *testing.T, port int) (*stdgrpc.Server, *trust.Service, func(
 
 	srv := stdgrpc.NewServer()
 	oidcmappingv1.RegisterServiceServer(srv, grpc.NewOIDCMappingServer(service))
-	sessionv1.RegisterServiceServer(srv, grpc.NewSessionServer(nil, trustRepo, time.Hour, ""))
+	sessionv1.RegisterServiceServer(srv, grpc.NewSessionServer(ctx, nil, trustRepo, time.Hour, ""))
 
 	// start
 	go func() {

--- a/integration/session_grpc_test.go
+++ b/integration/session_grpc_test.go
@@ -199,7 +199,7 @@ func startSessionServer(t *testing.T, port int) (*stdgrpc.Server, session.Reposi
 	}
 
 	srv := stdgrpc.NewServer()
-	sessionv1.RegisterServiceServer(srv, grpc.NewSessionServer(sessionRepo, trustRepo, 90*time.Minute, ""))
+	sessionv1.RegisterServiceServer(srv, grpc.NewSessionServer(ctx, sessionRepo, trustRepo, 90*time.Minute, ""))
 
 	// start
 	go func() {

--- a/internal/business/business.go
+++ b/internal/business/business.go
@@ -105,7 +105,7 @@ func internalMain(ctx context.Context, cfg *config.Config) error {
 
 	// Initialize the gRPC servers.
 	oidcmappingsrv := grpc.NewOIDCMappingServer(trustService)
-	sessionsrv := grpc.NewSessionServer(
+	sessionsrv := grpc.NewSessionServer(ctx,
 		sessionRepo,
 		trustRepo,
 		cfg.SessionManager.IdleSessionTimeout,
@@ -140,7 +140,7 @@ func initSessionManager(ctx context.Context, cfg *config.Config) (_ *session.Man
 		return nil, nil, fmt.Errorf("failed to create audit logger: %w", err)
 	}
 
-	sessManager, err := session.NewManager(
+	sessManager, err := session.NewManager(ctx,
 		&cfg.SessionManager,
 		trustRepo,
 		sessionRepo,

--- a/internal/business/server/grpc_server_test.go
+++ b/internal/business/server/grpc_server_test.go
@@ -27,7 +27,7 @@ func TestStartGRPCServer_ContextCancellation(t *testing.T) {
 
 		// Create minimal server instances
 		oidcmappingsrv := grpc.NewOIDCMappingServer(nil)
-		sessionsrv := grpc.NewSessionServer(nil, nil, 0, "")
+		sessionsrv := grpc.NewSessionServer(ctx, nil, nil, 0, "")
 
 		// Start the server in a goroutine
 		errChan := make(chan error, 1)

--- a/internal/grpc/session.go
+++ b/internal/grpc/session.go
@@ -9,8 +9,8 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/jellydator/ttlcache/v3"
 	"github.com/openkcm/common-sdk/pkg/oidc"
-	"github.com/patrickmn/go-cache"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/codes"
 	"google.golang.org/grpc/status"
@@ -27,6 +27,8 @@ import (
 	"github.com/openkcm/session-manager/internal/trust"
 )
 
+const defaultIntrospectionCacheExpiration = 30 * time.Second
+
 var debugSettingSMDumpTransport = debugtools.NewSetting("smdumptransport")
 
 type SessionServer struct {
@@ -41,10 +43,12 @@ type SessionServer struct {
 	allowHttpScheme           bool
 	clientID                  string
 
-	cache *cache.Cache
+	// cache introspection results
+	introspectionCache *ttlcache.Cache[string, oidc.Introspection]
 }
 
 func NewSessionServer(
+	ctx context.Context,
 	sessionRepo session.Repository,
 	trustRepo trust.OIDCMappingRepository,
 	idleSessionTimeout time.Duration,
@@ -55,7 +59,6 @@ func NewSessionServer(
 		sessionRepo:        sessionRepo,
 		trustRepo:          trustRepo,
 		idleSessionTimeout: idleSessionTimeout,
-		cache:              cache.New(2*time.Minute, 10*time.Minute),
 		newCreds:           func(clientID string) credentials.TransportCredentials { return credentials.NewInsecure(clientID) },
 		clientID:           clientID,
 	}
@@ -64,6 +67,13 @@ func NewSessionServer(
 			opt(s)
 		}
 	}
+
+	s.introspectionCache = ttlcache.New(ttlcache.WithTTL[string, oidc.Introspection](defaultIntrospectionCacheExpiration))
+	go s.introspectionCache.Start()
+	go func(ctx context.Context) {
+		<-ctx.Done()
+		s.introspectionCache.Stop()
+	}(ctx)
 
 	return s
 }
@@ -226,19 +236,11 @@ func (s *SessionServer) httpClient(mapping *trust.OIDCMapping) *http.Client {
 }
 
 func (s *SessionServer) introspectToken(ctx context.Context, token string, oidcTrust *trust.OIDCMapping) (oidc.Introspection, error) {
-	const introspectPrefix = "introspect_"
-
 	// first check the cache for a recent introspection result for this token
 	hashedSuffix := sha256.Sum256([]byte(token))
-	cacheKey := introspectPrefix + base64.RawURLEncoding.EncodeToString(hashedSuffix[:])
-
-	cache, ok := s.cache.Get(cacheKey)
-	if ok {
-		value, ok := cache.(oidc.Introspection)
-		if ok {
-			return value, nil
-		}
-		s.cache.Delete(cacheKey)
+	cacheKey := base64.RawURLEncoding.EncodeToString(hashedSuffix[:])
+	if item := s.introspectionCache.Get(cacheKey); item != nil {
+		return item.Value(), nil
 	}
 
 	httpClient := s.httpClient(oidcTrust)
@@ -254,7 +256,7 @@ func (s *SessionServer) introspectToken(ctx context.Context, token string, oidcT
 		return oidc.Introspection{Active: false}, err
 	}
 
-	// introspect the token and cache the result
+	// introspect the token
 	intr, err := provider.IntrospectToken(ctx, token)
 	if err != nil {
 		if errors.Is(err, oidc.ErrNoIntrospectionEndpoint) {
@@ -264,7 +266,9 @@ func (s *SessionServer) introspectToken(ctx context.Context, token string, oidcT
 		slogctx.Error(ctx, "Could not introspect access token", "error", err)
 		return oidc.Introspection{Active: false}, err
 	}
-	s.cache.Set(cacheKey, intr, 0)
+
+	// Cache the result with TTL
+	s.introspectionCache.Set(cacheKey, intr, ttlcache.DefaultTTL)
 
 	return intr, nil
 }

--- a/internal/grpc/session_test.go
+++ b/internal/grpc/session_test.go
@@ -25,12 +25,13 @@ import (
 )
 
 func TestNewSessionServer(t *testing.T) {
+	ctx := t.Context()
 	t.Run("creates server successfully", func(t *testing.T) {
 		sessionRepo := sessionmock.NewInMemRepository()
 		trustRepo := trustmock.NewInMemRepository()
 		idleSessionTimeout := 90 * time.Minute
 
-		server := grpc.NewSessionServer(sessionRepo, trustRepo, idleSessionTimeout, "")
+		server := grpc.NewSessionServer(ctx, sessionRepo, trustRepo, idleSessionTimeout, "")
 
 		assert.NotNil(t, server)
 	})
@@ -40,7 +41,7 @@ func TestNewSessionServer(t *testing.T) {
 		trustRepo := trustmock.NewInMemRepository()
 		idleSessionTimeout := 90 * time.Minute
 
-		server := grpc.NewSessionServer(
+		server := grpc.NewSessionServer(ctx,
 			sessionRepo,
 			trustRepo,
 			idleSessionTimeout,
@@ -56,7 +57,7 @@ func TestNewSessionServer(t *testing.T) {
 		trustRepo := trustmock.NewInMemRepository()
 		idleSessionTimeout := 90 * time.Minute
 
-		server := grpc.NewSessionServer(
+		server := grpc.NewSessionServer(ctx,
 			sessionRepo,
 			trustRepo,
 			idleSessionTimeout,
@@ -122,7 +123,7 @@ func TestGetSession(t *testing.T) {
 			trustmock.WithTrust(sess.TenantID, mapping),
 		)
 
-		server := grpc.NewSessionServer(sessionRepo, trustRepo, 90*time.Minute, "",
+		server := grpc.NewSessionServer(ctx, sessionRepo, trustRepo, 90*time.Minute, "",
 			grpc.WithAllowHttpScheme(true),
 		)
 
@@ -193,7 +194,7 @@ func TestGetSession(t *testing.T) {
 			trustmock.WithTrust(sess.TenantID, mapping),
 		)
 
-		server := grpc.NewSessionServer(sessionRepo, trustRepo, 90*time.Minute, "",
+		server := grpc.NewSessionServer(ctx, sessionRepo, trustRepo, 90*time.Minute, "",
 			grpc.WithAllowHttpScheme(true),
 		)
 
@@ -249,7 +250,7 @@ func TestGetSession(t *testing.T) {
 			trustmock.WithTrust(sess.TenantID, mapping),
 		)
 
-		server := grpc.NewSessionServer(sessionRepo, trustRepo, 90*time.Minute, "",
+		server := grpc.NewSessionServer(ctx, sessionRepo, trustRepo, 90*time.Minute, "",
 			grpc.WithAllowHttpScheme(true),
 		)
 
@@ -273,7 +274,7 @@ func TestGetSession(t *testing.T) {
 		)
 		trustRepo := trustmock.NewInMemRepository()
 
-		server := grpc.NewSessionServer(sessionRepo, trustRepo, 90*time.Minute, "")
+		server := grpc.NewSessionServer(ctx, sessionRepo, trustRepo, 90*time.Minute, "")
 
 		req := &sessionv1.GetSessionRequest{
 			SessionId:   "session-123",
@@ -302,7 +303,7 @@ func TestGetSession(t *testing.T) {
 
 		trustRepo := trustmock.NewInMemRepository()
 
-		server := grpc.NewSessionServer(sessionRepo, trustRepo, 90*time.Minute, "")
+		server := grpc.NewSessionServer(ctx, sessionRepo, trustRepo, 90*time.Minute, "")
 
 		req := &sessionv1.GetSessionRequest{
 			SessionId:   "session-789",
@@ -329,7 +330,7 @@ func TestGetSession(t *testing.T) {
 
 		trustRepo := trustmock.NewInMemRepository()
 
-		server := grpc.NewSessionServer(sessionRepo, trustRepo, 90*time.Minute, "")
+		server := grpc.NewSessionServer(ctx, sessionRepo, trustRepo, 90*time.Minute, "")
 
 		req := &sessionv1.GetSessionRequest{
 			SessionId:   "session-fail",
@@ -360,7 +361,7 @@ func TestGetSession(t *testing.T) {
 		// No mapping added to repo
 		trustRepo := trustmock.NewInMemRepository()
 
-		server := grpc.NewSessionServer(sessionRepo, trustRepo, 90*time.Minute, "")
+		server := grpc.NewSessionServer(ctx, sessionRepo, trustRepo, 90*time.Minute, "")
 
 		req := &sessionv1.GetSessionRequest{
 			SessionId:   "session-no-provider",
@@ -396,7 +397,7 @@ func TestGetSession(t *testing.T) {
 			trustmock.WithTrust(sess.TenantID, mapping),
 		)
 
-		server := grpc.NewSessionServer(sessionRepo, trustRepo, 90*time.Minute, "")
+		server := grpc.NewSessionServer(ctx, sessionRepo, trustRepo, 90*time.Minute, "")
 
 		req := &sessionv1.GetSessionRequest{
 			SessionId:   "session-blocked",
@@ -444,7 +445,7 @@ func TestGetSession(t *testing.T) {
 			trustmock.WithTrust(sess.TenantID, mapping),
 		)
 
-		server := grpc.NewSessionServer(sessionRepo, trustRepo, 90*time.Minute, "")
+		server := grpc.NewSessionServer(ctx, sessionRepo, trustRepo, 90*time.Minute, "")
 
 		req := &sessionv1.GetSessionRequest{
 			SessionId:   "session-fingerprint",
@@ -480,7 +481,7 @@ func TestGetSession(t *testing.T) {
 			trustmock.WithTrust("wrong-tenant", mapping),
 		)
 
-		server := grpc.NewSessionServer(sessionRepo, trustRepo, 90*time.Minute, "")
+		server := grpc.NewSessionServer(ctx, sessionRepo, trustRepo, 90*time.Minute, "")
 
 		req := &sessionv1.GetSessionRequest{
 			SessionId:   "session-tenant",
@@ -516,7 +517,7 @@ func TestGetSession(t *testing.T) {
 			trustmock.WithTrust(sess.TenantID, mapping),
 		)
 
-		server := grpc.NewSessionServer(sessionRepo, trustRepo, 90*time.Minute, "")
+		server := grpc.NewSessionServer(ctx, sessionRepo, trustRepo, 90*time.Minute, "")
 
 		req := &sessionv1.GetSessionRequest{
 			SessionId:   "session-config-fail",
@@ -568,7 +569,7 @@ func TestGetSession(t *testing.T) {
 			trustmock.WithTrust(sess.TenantID, mapping),
 		)
 
-		server := grpc.NewSessionServer(sessionRepo, trustRepo, 90*time.Minute, "",
+		server := grpc.NewSessionServer(ctx, sessionRepo, trustRepo, 90*time.Minute, "",
 			grpc.WithAllowHttpScheme(true),
 		)
 
@@ -624,7 +625,7 @@ func TestGetSession(t *testing.T) {
 			trustmock.WithTrust(sess.TenantID, mapping),
 		)
 
-		server := grpc.NewSessionServer(sessionRepo, trustRepo, 90*time.Minute, "",
+		server := grpc.NewSessionServer(ctx, sessionRepo, trustRepo, 90*time.Minute, "",
 			grpc.WithAllowHttpScheme(true),
 		)
 
@@ -673,7 +674,7 @@ func TestGetSession(t *testing.T) {
 			trustmock.WithTrust(sess.TenantID, mapping),
 		)
 
-		server := grpc.NewSessionServer(sessionRepo, trustRepo, 90*time.Minute, "",
+		server := grpc.NewSessionServer(ctx, sessionRepo, trustRepo, 90*time.Minute, "",
 			grpc.WithAllowHttpScheme(true),
 		)
 
@@ -692,6 +693,7 @@ func TestGetSession(t *testing.T) {
 }
 
 func TestWithQueryParametersIntrospect(t *testing.T) {
+	ctx := t.Context()
 	t.Run("sets query parameters correctly", func(t *testing.T) {
 		params := []string{"param1", "param2", "param3"}
 		opt := grpc.WithQueryParametersIntrospect(params)
@@ -702,7 +704,7 @@ func TestWithQueryParametersIntrospect(t *testing.T) {
 		sessionRepo := sessionmock.NewInMemRepository()
 		trustRepo := trustmock.NewInMemRepository()
 
-		server := grpc.NewSessionServer(
+		server := grpc.NewSessionServer(ctx,
 			sessionRepo,
 			trustRepo,
 			90*time.Minute,
@@ -729,7 +731,7 @@ func TestGetOIDCProvider(t *testing.T) {
 			trustmock.WithTrust("tenant-123", mapping),
 		)
 
-		server := grpc.NewSessionServer(sessionRepo, trustRepo, 90*time.Minute, "")
+		server := grpc.NewSessionServer(ctx, sessionRepo, trustRepo, 90*time.Minute, "")
 
 		req := &sessionv1.GetOIDCProviderRequest{
 			TenantId: "tenant-123",
@@ -749,7 +751,7 @@ func TestGetOIDCProvider(t *testing.T) {
 		sessionRepo := sessionmock.NewInMemRepository()
 		trustRepo := trustmock.NewInMemRepository()
 
-		server := grpc.NewSessionServer(sessionRepo, trustRepo, 90*time.Minute, "")
+		server := grpc.NewSessionServer(ctx, sessionRepo, trustRepo, 90*time.Minute, "")
 
 		req := &sessionv1.GetOIDCProviderRequest{
 			TenantId: "non-existent-tenant",
@@ -768,7 +770,7 @@ func TestGetOIDCProvider(t *testing.T) {
 			trustmock.WithGetError(errors.New("database connection error")),
 		)
 
-		server := grpc.NewSessionServer(sessionRepo, trustRepo, 90*time.Minute, "")
+		server := grpc.NewSessionServer(ctx, sessionRepo, trustRepo, 90*time.Minute, "")
 
 		req := &sessionv1.GetOIDCProviderRequest{
 			TenantId: "tenant-123",

--- a/internal/session/housekeeper_test.go
+++ b/internal/session/housekeeper_test.go
@@ -36,7 +36,7 @@ func TestDeleteIdleSessions(t *testing.T) {
 	err := sessions.BumpActive(ctx, sessionID, time.Hour)
 	require.NoError(t, err)
 
-	manager, err := session.NewManager(cfg, nil, sessions, nil)
+	manager, err := session.NewManager(ctx, cfg, nil, sessions, nil)
 	require.NoError(t, err)
 
 	// Session should be there before cleanup
@@ -134,7 +134,7 @@ func TestRefreshAccessToken(t *testing.T) {
 			CSRFSecretParsed:               []byte(testCSRFSecret),
 		}
 
-		manager, err := session.NewManager(
+		manager, err := session.NewManager(ctx,
 			cfg,
 			oidcRepo,
 			sessions,
@@ -176,7 +176,7 @@ func TestRefreshAccessToken(t *testing.T) {
 			CSRFSecretParsed: []byte(testCSRFSecret),
 		}
 
-		manager, err := session.NewManager(cfg, oidcRepo, sessions, nil)
+		manager, err := session.NewManager(ctx, cfg, oidcRepo, sessions, nil)
 		require.NoError(t, err)
 
 		// Trigger housekeeping - should log error but not fail
@@ -232,7 +232,7 @@ func TestRefreshAccessToken(t *testing.T) {
 			CSRFSecretParsed: []byte(testCSRFSecret),
 		}
 
-		manager, err := session.NewManager(
+		manager, err := session.NewManager(ctx,
 			cfg,
 			oidcRepo,
 			sessions,
@@ -290,7 +290,7 @@ func TestRefreshAccessToken(t *testing.T) {
 			CSRFSecretParsed:               []byte(testCSRFSecret),
 		}
 
-		manager, err := session.NewManager(
+		manager, err := session.NewManager(ctx,
 			cfg,
 			oidcRepo,
 			sessions,
@@ -325,7 +325,7 @@ func TestHousekeepSession_ErrorCases(t *testing.T) {
 			CSRFSecretParsed: []byte(testCSRFSecret),
 		}
 
-		manager, err := session.NewManager(cfg, nil, sessions, nil)
+		manager, err := session.NewManager(ctx, cfg, nil, sessions, nil)
 		require.NoError(t, err)
 
 		err = manager.TriggerHousekeeping(ctx, 1, time.Hour)
@@ -355,7 +355,7 @@ func TestHousekeepSession_ErrorCases(t *testing.T) {
 			CSRFSecretParsed: []byte(testCSRFSecret),
 		}
 
-		manager, err := session.NewManager(cfg, nil, sessions, nil)
+		manager, err := session.NewManager(ctx, cfg, nil, sessions, nil)
 		require.NoError(t, err)
 
 		// Trigger with short refresh interval - token should not be refreshed

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -16,9 +16,9 @@ import (
 	"github.com/go-jose/go-jose/v4"
 	"github.com/go-jose/go-jose/v4/jwt"
 	"github.com/google/uuid"
+	"github.com/jellydator/ttlcache/v3"
 	"github.com/openkcm/common-sdk/pkg/csrf"
 	"github.com/openkcm/common-sdk/pkg/oidc"
-	"github.com/patrickmn/go-cache"
 
 	otlpaudit "github.com/openkcm/common-sdk/pkg/otlp/audit"
 	slogctx "github.com/veqryn/slog-context"
@@ -30,6 +30,8 @@ import (
 	"github.com/openkcm/session-manager/internal/serviceerr"
 	"github.com/openkcm/session-manager/internal/trust"
 )
+
+const defaultWKOCCacheExpiration = 30 * time.Minute
 
 var debugSettingSMDumpTransport = debugtools.NewSetting("smdumptransport")
 
@@ -60,12 +62,14 @@ type Manager struct {
 
 	csrfSecret []byte
 
-	cache *cache.Cache
-
 	allowHttpScheme bool
+
+	// cache well known OpenID configuration results
+	wkocCache *ttlcache.Cache[string, *oidc.Configuration]
 }
 
 func NewManager(
+	ctx context.Context,
 	cfg *config.SessionManager,
 	trustRepo trust.OIDCMappingRepository,
 	sessionsRepo Repository,
@@ -95,7 +99,6 @@ func NewManager(
 		clientID:                cfg.ClientAuth.ClientID,
 		newCreds:                func(clientID string) credentials.TransportCredentials { return credentials.NewInsecure(clientID) },
 		csrfSecret:              cfg.CSRFSecretParsed,
-		cache:                   cache.New(2*time.Minute, 10*time.Minute),
 	}
 
 	for _, opt := range opts {
@@ -103,6 +106,13 @@ func NewManager(
 			opt(m)
 		}
 	}
+
+	m.wkocCache = ttlcache.New(ttlcache.WithTTL[string, *oidc.Configuration](defaultWKOCCacheExpiration))
+	go m.wkocCache.Start()
+	go func(ctx context.Context) {
+		<-ctx.Done()
+		m.wkocCache.Stop()
+	}(ctx)
 
 	return m, nil
 }

--- a/internal/session/manager_cookie_test.go
+++ b/internal/session/manager_cookie_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func TestManager_MakeSessionCookie(t *testing.T) {
+	ctx := t.Context()
 	tests := []struct {
 		name        string
 		cfg         *config.SessionManager
@@ -139,7 +140,7 @@ func TestManager_MakeSessionCookie(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			m, err := session.NewManager(
+			m, err := session.NewManager(ctx,
 				tt.cfg,
 				nil,
 				sessionmock.NewInMemRepository(),
@@ -165,6 +166,7 @@ func TestManager_MakeSessionCookie(t *testing.T) {
 }
 
 func TestManager_MakeCSRFCookie(t *testing.T) {
+	ctx := t.Context()
 	tests := []struct {
 		name        string
 		cfg         *config.SessionManager
@@ -289,7 +291,7 @@ func TestManager_MakeCSRFCookie(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			m, err := session.NewManager(
+			m, err := session.NewManager(ctx,
 				tt.cfg,
 				nil,
 				sessionmock.NewInMemRepository(),
@@ -315,6 +317,7 @@ func TestManager_MakeCSRFCookie(t *testing.T) {
 }
 
 func TestManager_MakeLoginCSRFCookie(t *testing.T) {
+	ctx := t.Context()
 	cfg := &config.SessionManager{
 		CSRFSecretParsed: []byte(testCSRFSecret),
 		LoginCSRFCookieTemplate: config.CookieTemplate{
@@ -327,7 +330,7 @@ func TestManager_MakeLoginCSRFCookie(t *testing.T) {
 		},
 	}
 
-	m, err := session.NewManager(cfg, nil, sessionmock.NewInMemRepository(), nil)
+	m, err := session.NewManager(ctx, cfg, nil, sessionmock.NewInMemRepository(), nil)
 	require.NoError(t, err)
 
 	cookie, err := m.MakeLoginCSRFCookie(t.Context(), "csrf-456")
@@ -339,6 +342,7 @@ func TestManager_MakeLoginCSRFCookie(t *testing.T) {
 }
 
 func TestManager_ValidateCSRFToken(t *testing.T) {
+	ctx := t.Context()
 	csrfSecret := []byte(testCSRFSecret)
 
 	cfg := &config.SessionManager{
@@ -361,7 +365,7 @@ func TestManager_ValidateCSRFToken(t *testing.T) {
 		},
 	}
 
-	m, err := session.NewManager(
+	m, err := session.NewManager(ctx,
 		cfg,
 		nil,
 		sessionmock.NewInMemRepository(),
@@ -412,6 +416,7 @@ func TestManager_ValidateCSRFToken(t *testing.T) {
 }
 
 func TestManager_Logout(t *testing.T) {
+	ctx := t.Context()
 	const (
 		sessionID     = "session-123"
 		tenantID      = "tenant-1"
@@ -488,7 +493,7 @@ func TestManager_Logout(t *testing.T) {
 
 			oidcRepo := tt.setupOIDCRepo(t)
 
-			m, err := session.NewManager(
+			m, err := session.NewManager(ctx,
 				tt.cfg,
 				oidcRepo,
 				sessionRepo,

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -36,6 +36,7 @@ const (
 )
 
 func TestManager_Auth(t *testing.T) {
+	ctx := t.Context()
 	const (
 		requestURI  = "http://localhost/request.jwt"
 		callbackURL = "http://localhost/sm/callback"
@@ -140,7 +141,7 @@ func TestManager_Auth(t *testing.T) {
 			auditLogger, err := otlpaudit.NewLogger(&commoncfg.Audit{Endpoint: auditServer.URL})
 			require.NoError(t, err)
 
-			m, err := session.NewManager(
+			m, err := session.NewManager(ctx,
 				tt.cfg,
 				tt.oidc,
 				tt.sessions,
@@ -369,7 +370,7 @@ func TestManager_FinaliseOIDCLogin(t *testing.T) {
 
 			tt.oidc.TAdd(tenantID, localOIDCMapping)
 
-			m, err := session.NewManager(
+			m, err := session.NewManager(ctx,
 				tt.cfg,
 				tt.oidc,
 				tt.sessions,
@@ -519,7 +520,7 @@ func TestManager_BCLogout(t *testing.T) {
 
 			tt.setupMock(oidcMock, sessionMock)
 
-			m, err := session.NewManager(
+			m, err := session.NewManager(ctx,
 				tt.cfg,
 				oidcMock,
 				sessionMock,
@@ -594,7 +595,7 @@ func TestManager_LogoutEdgeCases(t *testing.T) {
 				},
 			}
 
-			m, err := session.NewManager(cfg, oidcMock, sessionMock, auditLogger)
+			m, err := session.NewManager(ctx, cfg, oidcMock, sessionMock, auditLogger)
 			require.NoError(t, err)
 
 			_, err = m.Logout(ctx, tt.sessionID)
@@ -720,7 +721,7 @@ func TestManager_BCLogout_ErrorCases(t *testing.T) {
 				CSRFSecretParsed: []byte(testCSRFSecret),
 			}
 
-			m, err := session.NewManager(cfg, oidcMock, sessionMock, auditLogger, session.WithTransportCredentials(newTCBuilder(rt)))
+			m, err := session.NewManager(ctx, cfg, oidcMock, sessionMock, auditLogger, session.WithTransportCredentials(newTCBuilder(rt)))
 			require.NoError(t, err)
 
 			err = m.BCLogout(ctx, tt.jwt)
@@ -730,6 +731,7 @@ func TestManager_BCLogout_ErrorCases(t *testing.T) {
 }
 
 func TestManager_NewManager_Error(t *testing.T) {
+	ctx := t.Context()
 	auditServer := StartAuditServer(t)
 	defer auditServer.Close()
 
@@ -741,7 +743,7 @@ func TestManager_NewManager_Error(t *testing.T) {
 		CSRFSecretParsed: []byte(testCSRFSecret),
 	}
 
-	m, err := session.NewManager(cfg, trustmock.NewInMemRepository(), sessionmock.NewInMemRepository(), auditLogger)
+	m, err := session.NewManager(ctx, cfg, trustmock.NewInMemRepository(), sessionmock.NewInMemRepository(), auditLogger)
 	assert.Error(t, err)
 	assert.Nil(t, m)
 	assert.Contains(t, err.Error(), "parsing callback URL")

--- a/internal/session/openid.go
+++ b/internal/session/openid.go
@@ -5,26 +5,19 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 
+	"github.com/jellydator/ttlcache/v3"
 	"github.com/openkcm/common-sdk/pkg/oidc"
 )
 
 func (m *Manager) getOpenIDConfig(ctx context.Context, issuerURL string) (*oidc.Configuration, error) {
-	const wkocPrefix = "wkoc_"
-
 	// first check the cache for a recent WKOC configuration for this issuer
 	hashedSuffix := sha256.Sum256([]byte(issuerURL))
-	cacheKey := wkocPrefix + base64.RawURLEncoding.EncodeToString(hashedSuffix[:])
-
-	cache, ok := m.cache.Get(cacheKey)
-	if ok {
-		value, ok := cache.(*oidc.Configuration)
-		if ok {
-			return value, nil
-		}
-		m.cache.Delete(cacheKey)
+	cacheKey := base64.RawURLEncoding.EncodeToString(hashedSuffix[:])
+	if item := m.wkocCache.Get(cacheKey); item != nil {
+		return item.Value(), nil
 	}
 
-	// otherwise, fetch the configuration and cache it
+	// otherwise, fetch the configuration
 	provider, err := oidc.NewProvider(issuerURL, []string{},
 		oidc.WithAllowHttpScheme(m.allowHttpScheme),
 	)
@@ -35,7 +28,9 @@ func (m *Manager) getOpenIDConfig(ctx context.Context, issuerURL string) (*oidc.
 	if err != nil {
 		return nil, err
 	}
-	m.cache.Set(cacheKey, cfg, 0)
+
+	// Cache the result with TTL
+	m.wkocCache.Set(cacheKey, cfg, ttlcache.DefaultTTL)
 
 	return cfg, nil
 }


### PR DESCRIPTION
Switch from `github.com/patrickmn/go-cache` to `github.com/jellydator/ttlcache/v3`.