### PR TITLE
fix: validate redirect URLs

### DIFF
--- a/api/session-manager.yaml
+++ b/api/session-manager.yaml
@@ -68,6 +68,11 @@ paths:
                   required: true
                   schema:
                       type: string
+                - name: post_logout_redirect_uri
+                  in: query
+                  required: true
+                  schema:
+                      type: string
                 - name: "Cookie"
                   in: header
                   required: true

--- a/charts/session-manager/Chart.yaml
+++ b/charts/session-manager/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.9.2
+version: 0.9.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/internal/business/server/http_server.go
+++ b/internal/business/server/http_server.go
@@ -26,6 +26,7 @@ func createHTTPServer(_ context.Context, cfg *config.Config, sManager *session.M
 		cfg.SessionManager.CSRFSecretParsed,
 		cfg.SessionManager.SessionCookieTemplate.Name,
 		cfg.SessionManager.CSRFCookieTemplate.Name,
+		cfg.SessionManager.AllowedRedirectBaseURLs,
 	)
 	strictHandler := openapi.NewStrictHandler(
 		openAPIServer,

--- a/internal/business/server/openapi.go
+++ b/internal/business/server/openapi.go
@@ -3,7 +3,9 @@ package server
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/openkcm/common-sdk/pkg/csrf"
 	"github.com/openkcm/common-sdk/pkg/fingerprint"
@@ -26,7 +28,7 @@ type sessionManager interface {
 	MakeSessionCookie(ctx context.Context, tenantID, sessionID string) (*http.Cookie, error)
 	MakeCSRFCookie(ctx context.Context, tenantID, csrfToken string) (*http.Cookie, error)
 	MakeLoginCSRFCookie(ctx context.Context, csrfToken string) (*http.Cookie, error)
-	Logout(ctx context.Context, sessionID string) (string, error)
+	Logout(ctx context.Context, sessionID, postLogoutRedirectURL string) (string, error)
 	BCLogout(ctx context.Context, logoutToken string) error
 }
 
@@ -38,6 +40,7 @@ type openAPIServer struct {
 
 	sessionIDCookieNamePrefix string
 	csrfTokenCookieNamePrefix string
+	allowedRedirectBaseURLs   []string
 }
 
 // Ensure openAPIServer implements [openapi.StrictServerInterface]
@@ -49,12 +52,14 @@ func newOpenAPIServer(
 	csrfSecret []byte,
 	sessionIDCookieNamePrefix,
 	csrfTokenCookieNamePrefix string,
+	allowedRedirectBaseURLs []string,
 ) *openAPIServer {
 	return &openAPIServer{
 		sManager:                  sManager,
 		csrfSecret:                csrfSecret,
 		sessionIDCookieNamePrefix: sessionIDCookieNamePrefix,
 		csrfTokenCookieNamePrefix: csrfTokenCookieNamePrefix,
+		allowedRedirectBaseURLs:   allowedRedirectBaseURLs,
 	}
 }
 
@@ -66,6 +71,19 @@ func (s *openAPIServer) Auth(ctx context.Context, request openapi.AuthRequestObj
 
 	slogctx.Debug(ctx, "Auth() called", "tenantId", request.Params.TenantID, "requestUri", request.Params.RequestURI)
 	defer slogctx.Debug(ctx, "Auth() completed")
+
+	if !s.isAllowedRedirectBaseURL(request.Params.RequestURI) {
+		err := fmt.Errorf("request URI does not match an allowed redirect base URL: %s", request.Params.RequestURI)
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "request URI does not match an allowed redirect base URL")
+		slogctx.Error(ctx, "Request URI does not match an allowed redirect base URL", "requestURI", request.Params.RequestURI)
+
+		body, status := s.toErrorModel(err)
+		return openapi.AuthdefaultJSONResponse{
+			Body:       body,
+			StatusCode: status,
+		}, nil
+	}
 
 	fingerprint, err := fingerprint.ExtractFingerprint(ctx)
 	if err != nil {
@@ -226,8 +244,21 @@ func (s *openAPIServer) Logout(ctx context.Context, request openapi.LogoutReques
 	ctx, span := tracer.Tracer("").Start(ctx, "logout")
 	defer span.End()
 
-	slogctx.Debug(ctx, "Logout() called", "tenantId", request.Params.TenantID)
+	slogctx.Debug(ctx, "Logout() called", "tenantId", request.Params.TenantID, "postLogoutRedirectURI", request.Params.PostLogoutRedirectURI)
 	defer slogctx.Debug(ctx, "Logout() completed")
+
+	if !s.isAllowedRedirectBaseURL(request.Params.PostLogoutRedirectURI) {
+		err := fmt.Errorf("post logout redirect URI does not match an allowed redirect base URL: %s", request.Params.PostLogoutRedirectURI)
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "post logout redirect URI does not match an allowed redirect base URL")
+		slogctx.Error(ctx, "Post logout redirect URI does not match an allowed redirect base URL", "postLogoutRedirectURI", request.Params.PostLogoutRedirectURI)
+
+		body, status := s.toErrorModel(err)
+		return openapi.LogoutdefaultJSONResponse{
+			Body:       body,
+			StatusCode: status,
+		}, nil
+	}
 
 	rw, err := middleware.ResponseWriterFromContext(ctx)
 	if err != nil {
@@ -285,7 +316,7 @@ func (s *openAPIServer) Logout(ctx context.Context, request openapi.LogoutReques
 		}, nil
 	}
 
-	logoutURL, err := s.sManager.Logout(ctx, sessionCookie.Value)
+	logoutURL, err := s.sManager.Logout(ctx, sessionCookie.Value, request.Params.PostLogoutRedirectURI)
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "failed to logout user")
@@ -343,6 +374,15 @@ func (s *openAPIServer) toErrorModel(err error) (model openapi.ErrorModel, httpS
 		Error:            string(serviceErr.Err),
 		ErrorDescription: &serviceErr.Description,
 	}, serviceErr.HTTPStatus()
+}
+
+func (s *openAPIServer) isAllowedRedirectBaseURL(url string) bool {
+	for _, baseURL := range s.allowedRedirectBaseURLs {
+		if strings.HasPrefix(url, baseURL) {
+			return true
+		}
+	}
+	return false
 }
 
 func newBadRequest(description string) (model openapi.ErrorModel, httpStatus int) {

--- a/internal/business/server/openapi_test.go
+++ b/internal/business/server/openapi_test.go
@@ -19,6 +19,11 @@ import (
 	"github.com/openkcm/session-manager/internal/session"
 )
 
+const (
+	allowedBaseURL = "https://app.example.com"
+	postLogoutURL  = "https://app.example.com/logged-out"
+)
+
 // mockSessionManager is a mock implementation of sessionManager interface for testing
 type mockSessionManager struct {
 	makeAuthURIFunc         func(ctx context.Context, tenantID, fingerprint, requestURI string) (string, string, error)
@@ -26,7 +31,7 @@ type mockSessionManager struct {
 	makeSessionCookieFunc   func(ctx context.Context, tenantID, sessionID string) (*http.Cookie, error)
 	makeCSRFCookieFunc      func(ctx context.Context, tenantID, csrfToken string) (*http.Cookie, error)
 	makeLoginCSRFCookieFunc func(ctx context.Context, csrfToken string) (*http.Cookie, error)
-	logoutFunc              func(ctx context.Context, sessionID string) (string, error)
+	logoutFunc              func(ctx context.Context, sessionID, postLogoutRedirectURL string) (string, error)
 	bcLogoutFunc            func(ctx context.Context, logoutToken string) error
 }
 
@@ -65,9 +70,9 @@ func (m *mockSessionManager) MakeLoginCSRFCookie(ctx context.Context, csrfToken 
 	return nil, errors.New("not implemented")
 }
 
-func (m *mockSessionManager) Logout(ctx context.Context, sessionID string) (string, error) {
+func (m *mockSessionManager) Logout(ctx context.Context, sessionID, postLogoutRedirectURL string) (string, error) {
 	if m.logoutFunc != nil {
-		return m.logoutFunc(ctx, sessionID)
+		return m.logoutFunc(ctx, sessionID, postLogoutRedirectURL)
 	}
 	return "", errors.New("not implemented")
 }
@@ -85,7 +90,7 @@ func TestNewOpenAPIServer(t *testing.T) {
 		sessionCookieName := "session-id"
 		csrfCookieName := "csrf-token"
 
-		server := newOpenAPIServer(nil, csrfSecret, sessionCookieName, csrfCookieName)
+		server := newOpenAPIServer(nil, csrfSecret, sessionCookieName, csrfCookieName, []string{allowedBaseURL})
 
 		assert.NotNil(t, server)
 		assert.Equal(t, csrfSecret, server.csrfSecret)
@@ -97,7 +102,7 @@ func TestNewOpenAPIServer(t *testing.T) {
 func TestOpenAPIServer_Auth_ContextCanceled(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
-	server := newOpenAPIServer(nil, nil, "", "")
+	server := newOpenAPIServer(nil, nil, "", "", []string{allowedBaseURL})
 	req := openapi.AuthRequestObject{}
 	resp, err := server.Auth(ctx, req)
 	assert.NoError(t, err)
@@ -111,7 +116,7 @@ func TestOpenAPIServer_Auth_ContextCanceled(t *testing.T) {
 
 func TestOpenAPIServer_Auth_ExtractFingerprint_Failed(t *testing.T) {
 	ctx := t.Context()
-	server := newOpenAPIServer(nil, nil, "", "")
+	server := newOpenAPIServer(nil, nil, "", "", []string{allowedBaseURL})
 	req := openapi.AuthRequestObject{}
 	resp, err := server.Auth(ctx, req)
 	assert.NoError(t, err)
@@ -130,7 +135,7 @@ func TestOpenAPIServer_Auth_MakeAuthURI_Failed(t *testing.T) {
 			return "", "", errors.New("error")
 		},
 	}
-	server := newOpenAPIServer(mock, nil, "", "")
+	server := newOpenAPIServer(mock, nil, "", "", []string{allowedBaseURL})
 	req := openapi.AuthRequestObject{}
 	resp, err := server.Auth(ctx, req)
 	assert.NoError(t, err)
@@ -152,7 +157,7 @@ func TestOpenAPIServer_Auth_MakeCSRFCookie_Failed(t *testing.T) {
 			return nil, errors.New("error")
 		},
 	}
-	server := newOpenAPIServer(mock, nil, "", "")
+	server := newOpenAPIServer(mock, nil, "", "", []string{allowedBaseURL})
 	req := openapi.AuthRequestObject{}
 	resp, err := server.Auth(ctx, req)
 	assert.NoError(t, err)
@@ -173,8 +178,12 @@ func TestOpenAPIServer_Auth_MakeAuthURI_Success(t *testing.T) {
 			return &http.Cookie{Name: "csrf-token", Value: csrfToken}, nil
 		},
 	}
-	server := newOpenAPIServer(mock, nil, "", "")
-	req := openapi.AuthRequestObject{}
+	server := newOpenAPIServer(mock, nil, "", "", []string{"https://example.com"})
+	req := openapi.AuthRequestObject{
+		Params: openapi.AuthParams{
+			RequestURI: "https://example.com/redirect",
+		},
+	}
 	resp, err := server.Auth(ctx, req)
 	assert.NoError(t, err)
 
@@ -188,7 +197,7 @@ func TestOpenAPIServer_Auth_MakeAuthURI_Success(t *testing.T) {
 func TestOpenAPIServer_Callback_ContextCanceled(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
-	server := newOpenAPIServer(nil, nil, "", "")
+	server := newOpenAPIServer(nil, nil, "", "", []string{allowedBaseURL})
 	req := openapi.CallbackRequestObject{}
 	resp, err := server.Callback(ctx, req)
 	assert.NoError(t, err)
@@ -202,7 +211,7 @@ func TestOpenAPIServer_Callback_ContextCanceled(t *testing.T) {
 
 func TestOpenAPIServer_Callback_ExtractFingerprint_Failed(t *testing.T) {
 	t.Run("returns an error when response writer is not in the context", func(t *testing.T) {
-		server := newOpenAPIServer(nil, nil, "", "")
+		server := newOpenAPIServer(nil, nil, "", "", []string{allowedBaseURL})
 		ctx := t.Context()
 
 		callbackReq := openapi.CallbackRequestObject{
@@ -229,7 +238,7 @@ func TestOpenAPIServer_Callback_NoResponseWriter(t *testing.T) {
 	t.Run("returns an error when fingerprint is not in the context", func(t *testing.T) {
 		ctx := fingerprint.WithFingerprint(t.Context(), "fingerprint")
 
-		server := newOpenAPIServer(nil, nil, "", "")
+		server := newOpenAPIServer(nil, nil, "", "", []string{allowedBaseURL})
 
 		callbackReq := openapi.CallbackRequestObject{
 			Params: openapi.CallbackParams{
@@ -266,7 +275,7 @@ func TestOpenAPIServer_Callback_FinaliseOIDCLogin_Failed(t *testing.T) {
 			},
 		}
 
-		server := newOpenAPIServer(mock, csrfSecret, "", "")
+		server := newOpenAPIServer(mock, csrfSecret, "", "", []string{allowedBaseURL})
 
 		callbackReq := openapi.CallbackRequestObject{
 			Params: openapi.CallbackParams{
@@ -311,7 +320,7 @@ func TestOpenAPIServer_Callback_MakeSessionCookie_Failed(t *testing.T) {
 			},
 		}
 
-		server := newOpenAPIServer(mock, csrfSecret, "", "")
+		server := newOpenAPIServer(mock, csrfSecret, "", "", []string{allowedBaseURL})
 
 		callbackReq := openapi.CallbackRequestObject{
 			Params: openapi.CallbackParams{
@@ -340,7 +349,7 @@ func TestOpenAPIServer_Callback_InvalidCsrfToken_Failed(t *testing.T) {
 
 		csrfSecret := []byte("test-secret")
 
-		server := newOpenAPIServer(nil, csrfSecret, "", "")
+		server := newOpenAPIServer(nil, csrfSecret, "", "", []string{allowedBaseURL})
 
 		callbackReq := openapi.CallbackRequestObject{
 			Params: openapi.CallbackParams{
@@ -389,7 +398,7 @@ func TestOpenAPIServer_Callback_MakeCSRFCookie_Failed(t *testing.T) {
 			},
 		}
 
-		server := newOpenAPIServer(mock, csrfSecret, "", "")
+		server := newOpenAPIServer(mock, csrfSecret, "", "", []string{allowedBaseURL})
 
 		callbackReq := openapi.CallbackRequestObject{
 			Params: openapi.CallbackParams{
@@ -438,7 +447,7 @@ func TestOpenAPIServer_Callback_Success(t *testing.T) {
 			},
 		}
 
-		server := newOpenAPIServer(mock, csrfSecret, "", "")
+		server := newOpenAPIServer(mock, csrfSecret, "", "", []string{allowedBaseURL})
 
 		callbackReq := openapi.CallbackRequestObject{
 			Params: openapi.CallbackParams{
@@ -472,7 +481,7 @@ func TestOpenAPIServer_Callback_Success(t *testing.T) {
 
 func TestOpenAPIServer_Logout_NoResponseWriter(t *testing.T) {
 	t.Run("returns an error when response writer is not in context", func(t *testing.T) {
-		server := newOpenAPIServer(nil, nil, "", "")
+		server := newOpenAPIServer(nil, nil, "", "", []string{allowedBaseURL})
 		ctx := t.Context()
 
 		logoutReq := openapi.LogoutRequestObject{
@@ -495,14 +504,15 @@ func TestOpenAPIServer_Logout_NoResponseWriter(t *testing.T) {
 
 func TestOpenAPIServer_Logout_InvalidCookie(t *testing.T) {
 	t.Run("returns an error for invalid cookie header", func(t *testing.T) {
-		server := newOpenAPIServer(nil, nil, "", "")
+		server := newOpenAPIServer(nil, nil, "", "", []string{allowedBaseURL})
 
 		rw := httptest.NewRecorder()
 		ctx := context.WithValue(t.Context(), middleware.ResponseWriterKey, rw)
 
 		logoutReq := openapi.LogoutRequestObject{
 			Params: openapi.LogoutParams{
-				Cookie: "invalid cookie format\n\n",
+				PostLogoutRedirectURI: postLogoutURL,
+				Cookie:                "invalid cookie format\n\n",
 			},
 		}
 
@@ -520,14 +530,15 @@ func TestOpenAPIServer_Logout_InvalidCookie(t *testing.T) {
 
 func TestOpenAPIServer_Logout_MissingSessionCookie(t *testing.T) {
 	t.Run("returns an error when session cookie is missing", func(t *testing.T) {
-		server := newOpenAPIServer(nil, []byte("secret"), "session-id", "csrf-token")
+		server := newOpenAPIServer(nil, []byte("secret"), "session-id", "csrf-token", []string{allowedBaseURL})
 
 		rw := httptest.NewRecorder()
 		ctx := context.WithValue(t.Context(), middleware.ResponseWriterKey, rw)
 
 		logoutReq := openapi.LogoutRequestObject{
 			Params: openapi.LogoutParams{
-				Cookie: "csrf-token=some-token",
+				PostLogoutRedirectURI: postLogoutURL,
+				Cookie:                "csrf-token=some-token",
 			},
 		}
 
@@ -549,12 +560,12 @@ func TestOpenAPIServer_Logout_Failed(t *testing.T) {
 		const tokenKey = "test-secret-32-bytes-length!!"
 		const tenantID = "tenant-1"
 		mock := &mockSessionManager{
-			logoutFunc: func(ctx context.Context, sessionID string) (string, error) {
+			logoutFunc: func(ctx context.Context, sessionID, postLogoutRedirectURL string) (string, error) {
 				return "", errors.New("error")
 			},
 		}
 
-		server := newOpenAPIServer(mock, []byte(tokenKey), "session-id", "csrf-token")
+		server := newOpenAPIServer(mock, []byte(tokenKey), "session-id", "csrf-token", []string{allowedBaseURL})
 
 		rw := httptest.NewRecorder()
 		ctx := context.WithValue(t.Context(), middleware.ResponseWriterKey, rw)
@@ -562,8 +573,9 @@ func TestOpenAPIServer_Logout_Failed(t *testing.T) {
 		token := csrf.NewToken("session-123", []byte(tokenKey))
 		logoutReq := openapi.LogoutRequestObject{
 			Params: openapi.LogoutParams{
-				TenantID: tenantID,
-				Cookie:   "session-id-" + tenantID + "=session-123; csrf-token-" + tenantID + "=" + token,
+				TenantID:              tenantID,
+				PostLogoutRedirectURI: postLogoutURL,
+				Cookie:                "session-id-" + tenantID + "=session-123; csrf-token-" + tenantID + "=" + token,
 			},
 		}
 
@@ -579,7 +591,7 @@ func TestOpenAPIServer_Logout_Failed(t *testing.T) {
 }
 
 func TestOpenAPIServer_ToErrorModel(t *testing.T) {
-	server := newOpenAPIServer(nil, nil, "", "")
+	server := newOpenAPIServer(nil, nil, "", "", []string{allowedBaseURL})
 
 	t.Run("converts service error to error model", func(t *testing.T) {
 		err := serviceerr.ErrUnauthorized
@@ -668,7 +680,7 @@ func TestOpenAPIServer_Bclogout_Success(t *testing.T) {
 				return nil
 			},
 		}
-		server := newOpenAPIServer(mock, nil, "", "")
+		server := newOpenAPIServer(mock, nil, "", "", []string{allowedBaseURL})
 
 		bclogoutReq := openapi.BclogoutRequestObject{
 			Body: &openapi.BclogoutFormdataRequestBody{
@@ -690,7 +702,7 @@ func TestOpenAPIServer_Bclogout_Error(t *testing.T) {
 				return serviceerr.ErrInvalidCSRFToken
 			},
 		}
-		server := newOpenAPIServer(mock, nil, "", "")
+		server := newOpenAPIServer(mock, nil, "", "", []string{allowedBaseURL})
 
 		bclogoutReq := openapi.BclogoutRequestObject{
 			Body: &openapi.BclogoutFormdataRequestBody{
@@ -716,20 +728,22 @@ func TestOpenAPIServer_Logout_Success(t *testing.T) {
 		tenantID := "tenant-1"
 
 		mock := &mockSessionManager{
-			logoutFunc: func(ctx context.Context, sid string) (string, error) {
+			logoutFunc: func(ctx context.Context, sid, postLogoutRedirectURL string) (string, error) {
 				assert.Equal(t, sessionID, sid)
+				assert.Equal(t, postLogoutURL, postLogoutRedirectURL)
 				return expectedURL, nil
 			},
 		}
-		server := newOpenAPIServer(mock, nil, "session-id", "csrf-token")
+		server := newOpenAPIServer(mock, nil, "session-id", "csrf-token", []string{allowedBaseURL})
 
 		rw := httptest.NewRecorder()
 		ctx := context.WithValue(context.Background(), middleware.ResponseWriterKey, rw)
 
 		logoutReq := openapi.LogoutRequestObject{
 			Params: openapi.LogoutParams{
-				TenantID: tenantID,
-				Cookie:   "session-id-" + tenantID + "=" + sessionID + "; csrf-token-" + tenantID + "=csrf-token",
+				TenantID:              tenantID,
+				PostLogoutRedirectURI: postLogoutURL,
+				Cookie:                "session-id-" + tenantID + "=" + sessionID + "; csrf-token-" + tenantID + "=csrf-token",
 			},
 		}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -72,7 +72,6 @@ type SessionManager struct {
 	AdditionalQueryParametersIntrospect []string            `yaml:"additionalQueryParametersIntrospect"`
 	AdditionalQueryParametersLogout     []string            `yaml:"additionalQueryParametersLogout"`
 	AdditionalAuthContextKeys           []string            `yaml:"additionalAuthContextKeys"`
-	PostLogoutRedirectURL               string              `yaml:"postLogoutRedirectURL"`
 	// SessionCookieTemplate defines the template attributes for the session cookie.
 	SessionCookieTemplate CookieTemplate `yaml:"sessionCookieTemplate"`
 	// CSRFCookieTemplate defines the template attributes for the CSRF cookie.
@@ -80,6 +79,13 @@ type SessionManager struct {
 	// LoginCSRFCookieTemplate defines the template attributes for the CSRF cookie.
 	LoginCSRFCookieTemplate CookieTemplate `yaml:"loginCSRFCookieTemplate"`
 
+	// AllowedRedirectBaseURLs defines the list of allowed base URLs for redirection
+	// during the authorization flow and post logout. This is used to validate the redirect
+	// URLs provided in the authorization request and post logout requests.
+	AllowedRedirectBaseURLs []string `yaml:"allowedRedirectBaseURLs"`
+
+	// Deprecated: use AllowedRedirectBaseURLs instead.
+	PostLogoutRedirectURL string `yaml:"postLogoutRedirectURL"`
 	// Deprecated: not used anymore. Kept for a helm issue with the migrate job.
 	RedirectURL string `yaml:"redirectURL" default:"/sm/redirect"`
 	// Deprecated: use AdditionalQueryParametersAuthorize instead.

--- a/internal/openapi/server.go
+++ b/internal/openapi/server.go
@@ -42,8 +42,9 @@ type CallbackParams struct {
 
 // LogoutParams defines parameters for Logout.
 type LogoutParams struct {
-	TenantID string `form:"tenant_id" json:"tenant_id"`
-	Cookie   string `json:"Cookie"`
+	TenantID              string `form:"tenant_id" json:"tenant_id"`
+	PostLogoutRedirectURI string `form:"post_logout_redirect_uri" json:"post_logout_redirect_uri"`
+	Cookie                string `json:"Cookie"`
 }
 
 // BclogoutFormdataRequestBody defines body for Bclogout for application/x-www-form-urlencoded ContentType.
@@ -224,6 +225,21 @@ func (siw *ServerInterfaceWrapper) Logout(w http.ResponseWriter, r *http.Request
 	err = runtime.BindQueryParameter("form", true, true, "tenant_id", r.URL.Query(), &params.TenantID)
 	if err != nil {
 		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "tenant_id", Err: err})
+		return
+	}
+
+	// ------------- Required query parameter "post_logout_redirect_uri" -------------
+
+	if paramValue := r.URL.Query().Get("post_logout_redirect_uri"); paramValue != "" {
+
+	} else {
+		siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "post_logout_redirect_uri"})
+		return
+	}
+
+	err = runtime.BindQueryParameter("form", true, true, "post_logout_redirect_uri", r.URL.Query(), &params.PostLogoutRedirectURI)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "post_logout_redirect_uri", Err: err})
 		return
 	}
 

--- a/internal/serviceerr/errors.go
+++ b/internal/serviceerr/errors.go
@@ -65,17 +65,16 @@ var (
 
 // Custom defined
 var (
-	ErrUnknown                = newErr("unknown error", CodeUnknown)
-	ErrConflict               = newErr("already exists", CodeConflict)
-	ErrNotFound               = newErr("not found", CodeNotFound)
-	ErrFingerprintMismatch    = newErr("fingerprint mismatch", CodeFingerprintMismatch)
-	ErrStateExpired           = newErr("state expired", CodeStateExpired)
-	ErrInvalidOIDCProvider    = newErr("invalid OIDC provider", CodeInvalidOIDCProvider)
-	ErrInvalidCSRFToken       = newErr("invalid CSRF token", CodeInvalidCSRFToken)
-	ErrUnauthorized           = newErr("unauthorized", CodeUnauthorizedClient)
-	ErrInvalidAtHash          = newErr("invalid atHash token", CodeInvalidAtHashToken)
-	ErrEndSessionNotSupported = newErr("the provider does not support end session", CodeEndSessionNotSupported)
-	ErrInvalidLoginCSRFToken  = newErr("invalid login CSRF token", CodeInvalidLoginCSRFToken)
+	ErrUnknown               = newErr("unknown error", CodeUnknown)
+	ErrConflict              = newErr("already exists", CodeConflict)
+	ErrNotFound              = newErr("not found", CodeNotFound)
+	ErrFingerprintMismatch   = newErr("fingerprint mismatch", CodeFingerprintMismatch)
+	ErrStateExpired          = newErr("state expired", CodeStateExpired)
+	ErrInvalidOIDCProvider   = newErr("invalid OIDC provider", CodeInvalidOIDCProvider)
+	ErrInvalidCSRFToken      = newErr("invalid CSRF token", CodeInvalidCSRFToken)
+	ErrUnauthorized          = newErr("unauthorized", CodeUnauthorizedClient)
+	ErrInvalidAtHash         = newErr("invalid atHash token", CodeInvalidAtHashToken)
+	ErrInvalidLoginCSRFToken = newErr("invalid login CSRF token", CodeInvalidLoginCSRFToken)
 )
 
 //nolint:recvcheck

--- a/internal/serviceerr/errors_test.go
+++ b/internal/serviceerr/errors_test.go
@@ -203,7 +203,6 @@ func TestPredefinedErrors(t *testing.T) {
 		{name: "ErrInvalidCSRFToken", err: serviceerr.ErrInvalidCSRFToken, expectedErr: serviceerr.CodeInvalidCSRFToken, hasDesc: true},
 		{name: "ErrUnauthorized", err: serviceerr.ErrUnauthorized, expectedErr: serviceerr.CodeUnauthorizedClient, hasDesc: true},
 		{name: "ErrInvalidAtHash", err: serviceerr.ErrInvalidAtHash, expectedErr: serviceerr.CodeInvalidAtHashToken, hasDesc: true},
-		{name: "ErrEndSessionNotSupported", err: serviceerr.ErrEndSessionNotSupported, expectedErr: serviceerr.CodeEndSessionNotSupported, hasDesc: true},
 	}
 
 	for _, tt := range tests {

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -54,7 +54,6 @@ type Manager struct {
 	queryParametersToken  []string
 	authContextKeys       []string
 	queryParametersLogout []string
-	postLogoutRedirectURL string
 
 	sessionCookieTemplate   config.CookieTemplate
 	csrfCookieTemplate      config.CookieTemplate
@@ -91,7 +90,6 @@ func NewManager(
 		queryParametersToken:    cfg.AdditionalQueryParametersToken,
 		authContextKeys:         cfg.AdditionalAuthContextKeys,
 		queryParametersLogout:   cfg.AdditionalQueryParametersLogout,
-		postLogoutRedirectURL:   cfg.PostLogoutRedirectURL,
 		sessionCookieTemplate:   cfg.SessionCookieTemplate,
 		csrfCookieTemplate:      cfg.CSRFCookieTemplate,
 		loginCSRFCookieTemplate: cfg.LoginCSRFCookieTemplate,
@@ -369,7 +367,7 @@ func (m *Manager) FinaliseOIDCLogin(ctx context.Context, stateID, code, fingerpr
 	}, nil
 }
 
-func (m *Manager) Logout(ctx context.Context, sessionID string) (string, error) {
+func (m *Manager) Logout(ctx context.Context, sessionID, postLogoutRedirectURL string) (string, error) {
 	session, err := m.sessions.LoadSession(ctx, sessionID)
 	if err != nil {
 		slogctx.Warn(ctx, "failed to get session by id", "error", err)
@@ -399,13 +397,7 @@ func (m *Manager) Logout(ctx context.Context, sessionID string) (string, error) 
 
 	if oidcConf.EndSessionEndpoint == "" {
 		slogctx.Warn(ctx, "the provider does not support RP-Initiated Logout")
-
-		// Redirect to the landing page if possible
-		if m.postLogoutRedirectURL != "" {
-			return m.postLogoutRedirectURL, nil
-		}
-
-		return "", serviceerr.ErrEndSessionNotSupported
+		return postLogoutRedirectURL, nil
 	}
 
 	redirectURL, err := url.Parse(oidcConf.EndSessionEndpoint)
@@ -416,9 +408,7 @@ func (m *Manager) Logout(ctx context.Context, sessionID string) (string, error) 
 
 	vals := make(url.Values, 2)
 	vals.Set("client_id", m.getClientID(mapping))
-	if m.postLogoutRedirectURL != "" {
-		vals.Set("post_logout_redirect_uri", m.postLogoutRedirectURL)
-	}
+	vals.Set("post_logout_redirect_uri", postLogoutRedirectURL)
 
 	for _, parameter := range m.queryParametersLogout {
 		value, ok := mapping.Properties[parameter]

--- a/internal/session/manager_cookie_test.go
+++ b/internal/session/manager_cookie_test.go
@@ -435,8 +435,7 @@ func TestManager_Logout(t *testing.T) {
 		{
 			name: "Success - redirect to postLogoutURL when no end session endpoint",
 			cfg: &config.SessionManager{
-				CSRFSecretParsed:      []byte(testCSRFSecret),
-				PostLogoutRedirectURL: postLogoutURL,
+				CSRFSecretParsed: []byte(testCSRFSecret),
 				ClientAuth: config.ClientAuth{
 					ClientID: testClientID,
 				},
@@ -502,7 +501,7 @@ func TestManager_Logout(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			logoutURL, err := m.Logout(t.Context(), sessionID)
+			logoutURL, err := m.Logout(t.Context(), sessionID, postLogoutURL)
 
 			if tt.wantErr {
 				assert.Error(t, err)

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -539,8 +539,9 @@ func TestManager_BCLogout(t *testing.T) {
 
 func TestManager_LogoutEdgeCases(t *testing.T) {
 	const (
-		tenantID  = "tenant-id"
-		sessionID = "session-id"
+		tenantID      = "tenant-id"
+		sessionID     = "session-id"
+		postLogoutURL = "https://app.example.com/logged-out"
 	)
 
 	tests := []struct {
@@ -598,7 +599,7 @@ func TestManager_LogoutEdgeCases(t *testing.T) {
 			m, err := session.NewManager(ctx, cfg, oidcMock, sessionMock, auditLogger)
 			require.NoError(t, err)
 
-			_, err = m.Logout(ctx, tt.sessionID)
+			_, err = m.Logout(ctx, tt.sessionID, postLogoutURL)
 			tt.errAssert(t, err)
 		})
 	}


### PR DESCRIPTION
This PR:

- defines an allow list in the config used to validate redirect URLs to avoid open redirect attacks
- implements the validation for the existing `RequestURI` in the `/sm/auth` call
- adds a post logout redirect URI to the `/sm/logout` call
- implements the validation for the new `PostLogoutRedirectURI` in the `/sm/logout` call
- deprecates the `PostLogoutRedirectURL` in the configuration