### PR TITLE
fix: chart regarding default cookie values

### DIFF
--- a/charts/session-manager/Chart.yaml
+++ b/charts/session-manager/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.9.3
+version: 0.9.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/session-manager/values.yaml
+++ b/charts/session-manager/values.yaml
@@ -342,8 +342,8 @@ config:
     loginCSRFCookieTemplate:
       path: "/"
       secure: true
-      sameSite: Strict
-      domain: localhost
+      sameSite: Lax
+      httpOnly: true
     csrfSecret:
       source: embedded
       value: my-csrf-secret-at-least-thirty-two-bits-size

--- a/config.yaml
+++ b/config.yaml
@@ -242,8 +242,8 @@ sessionManager:
     loginCSRFCookieTemplate:
         path: "/"
         secure: true
-        sameSite: Strict
-        domain: localhost
+        sameSite: Lax
+        httpOnly: true
     csrfSecret:
         source: embedded
         value: my-csrf-secret-at-least-thirty-two-bits-size


### PR DESCRIPTION
For the login CSRF cookie we need:

- the empty string as default domain
- SameSite=Lax because of the redirect from the IDP
- httpOnly=true because this token is not meant to be read by javascript
