### PR TITLE
retract versions 1.0.0 & 1.0.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -206,6 +206,7 @@ require (
 )
 
 retract (
+	v1.0.2
 	v1.0.1
 	v1.0.0
 )


### PR DESCRIPTION
How it works: https://www.jvt.me/posts/2024/01/15/retract-go-release/