### PR TITLE
fix(helm): make image.tag or image.digest mandatory

### DIFF
--- a/charts/session-manager/Chart.yaml
+++ b/charts/session-manager/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.9.4
+version: 0.9.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/session-manager/templates/_helpers.tpl
+++ b/charts/session-manager/templates/_helpers.tpl
@@ -75,11 +75,12 @@ Create the name of the service account to use
 
 {{/*
 Util function for generating the image URL based on the provided options.
+Either image.tag or image.digest must be set explicitly; no fallback to appVersion.
 */}}
 {{- define "session-manager.image" -}}
-{{- $defaultTag := index . 1 -}}
 {{- with index . 0 -}}
+{{- if not (or .digest .tag) -}}{{ fail "Either image.tag or image.digest must be set" }}{{- end -}}
 {{- if .registry -}}{{ printf "%s/%s" .registry .repository }}{{- else -}}{{- .repository -}}{{- end -}}
-{{- if .digest -}}{{ printf "@%s" .digest }}{{- else -}}{{ printf ":%s" (default $defaultTag .tag) }}{{- end -}}
+{{- if .digest -}}{{ printf "@%s" .digest }}{{- else -}}{{ printf ":%s" .tag }}{{- end -}}
 {{- end }}
 {{- end }}

--- a/charts/session-manager/templates/housekeeper/deployment.yaml
+++ b/charts/session-manager/templates/housekeeper/deployment.yaml
@@ -47,7 +47,7 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          image: "{{ template "session-manager.image" (tuple .Values.image $.Chart.AppVersion) }}"
+          image: "{{ template "session-manager.image" (tuple .Values.image) }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- with .Values.image.command }}
           command: {{ . }}

--- a/charts/session-manager/templates/session-manager/deployment.yaml
+++ b/charts/session-manager/templates/session-manager/deployment.yaml
@@ -49,7 +49,7 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          image: "{{ template "session-manager.image" (tuple .Values.image $.Chart.AppVersion) }}"
+          image: "{{ template "session-manager.image" (tuple .Values.image) }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- with .Values.image.command }}
           command: {{ . }}

--- a/charts/session-manager/values.yaml
+++ b/charts/session-manager/values.yaml
@@ -34,9 +34,8 @@ image:
   # command: [ "/bin/session-manager" ]
 
   # Override the image tag to deploy by setting this variable.
-  # If no value is set, the chart's appVersion is used.
   # +docs:property
-  tag: latest
+  tag: ""
 
   # Setting a digest will override any tag.
   # +docs:property

--- a/helm-tests/unit/chart_test.go
+++ b/helm-tests/unit/chart_test.go
@@ -91,7 +91,9 @@ func TestFullChartRendering(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			args := []string{"template", appName, path}
+			args := []string{"template", appName, path,
+				"--set", "image.tag=latest",
+			}
 			if tt.values != "" {
 				args = append(args, strings.Split(tt.values, " ")...)
 			}
@@ -148,7 +150,9 @@ func TestChartValidation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			args := []string{"template", appName, path, "--debug"}
+			args := []string{"template", appName, path, "--debug",
+				"--set", "image.tag=latest",
+			}
 			if tt.values != "" {
 				args = append(args, strings.Split(tt.values, " ")...)
 			}
@@ -198,7 +202,9 @@ func TestLabelsAndAnnotations(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			args := []string{"template", appName, path}
+			args := []string{"template", appName, path,
+				"--set", "image.tag=latest",
+			}
 			if tt.values != "" {
 				args = append(args, strings.Split(tt.values, " ")...)
 			}

--- a/helm-tests/unit/configmap_test.go
+++ b/helm-tests/unit/configmap_test.go
@@ -163,7 +163,9 @@ func TestConfigMapRendering(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			args := []string{"template", appName, path, "-s", "templates/configmap.yaml"}
+			args := []string{"template", appName, path, "-s", "templates/configmap.yaml",
+				"--set", "image.tag=latest",
+			}
 			if tt.values != "" {
 				args = append(args, strings.Split(tt.values, " ")...)
 			}

--- a/helm-tests/unit/deployment_test.go
+++ b/helm-tests/unit/deployment_test.go
@@ -278,7 +278,9 @@ func TestDeploymentRendering(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			args := []string{"template", appName, path, "-s", "templates/session-manager/deployment.yaml"}
+			args := []string{"template", appName, path, "-s", "templates/session-manager/deployment.yaml",
+				"--set", "image.tag=latest",
+			}
 			if tt.values != "" {
 				args = append(args, strings.Split(tt.values, " ")...)
 			}
@@ -473,7 +475,9 @@ func TestHousekeeperDeployment(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			args := []string{"template", appName, path, "-s", "templates/housekeeper/deployment.yaml"}
+			args := []string{"template", appName, path, "-s", "templates/housekeeper/deployment.yaml",
+				"--set", "image.tag=latest",
+			}
 			if tt.values != "" {
 				args = append(args, strings.Split(tt.values, " ")...)
 			}

--- a/helm-tests/unit/hpa_test.go
+++ b/helm-tests/unit/hpa_test.go
@@ -62,7 +62,9 @@ func TestHPARendering(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			args := []string{"template", appName, path, "-s", "templates/session-manager/hpa.yaml"}
+			args := []string{"template", appName, path, "-s", "templates/session-manager/hpa.yaml",
+				"--set", "image.tag=latest",
+			}
 			if tt.values != "" {
 				args = append(args, strings.Split(tt.values, " ")...)
 			}

--- a/helm-tests/unit/job_test.go
+++ b/helm-tests/unit/job_test.go
@@ -177,7 +177,9 @@ func TestMigrateJobRendering(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			args := []string{"template", appName, path, "-s", "templates/migrate/job.yaml"}
+			args := []string{"template", appName, path, "-s", "templates/migrate/job.yaml",
+				"--set", "image.tag=latest",
+			}
 			if tt.values != "" {
 				args = append(args, strings.Split(tt.values, " ")...)
 			}

--- a/helm-tests/unit/pdb_test.go
+++ b/helm-tests/unit/pdb_test.go
@@ -54,7 +54,9 @@ func TestPDBRendering(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			args := []string{"template", appName, path, "-s", "templates/session-manager/pdb.yaml"}
+			args := []string{"template", appName, path, "-s", "templates/session-manager/pdb.yaml",
+				"--set", "image.tag=latest",
+			}
 			if tt.values != "" {
 				args = append(args, strings.Split(tt.values, " ")...)
 			}

--- a/helm-tests/unit/service_test.go
+++ b/helm-tests/unit/service_test.go
@@ -95,7 +95,9 @@ func TestServiceRendering(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			args := []string{"template", appName, path, "-s", "templates/session-manager/service.yaml"}
+			args := []string{"template", appName, path, "-s", "templates/session-manager/service.yaml",
+				"--set", "image.tag=latest",
+			}
 			if tt.values != "" {
 				args = append(args, strings.Split(tt.values, " ")...)
 			}

--- a/helm-tests/unit/serviceaccount_test.go
+++ b/helm-tests/unit/serviceaccount_test.go
@@ -76,7 +76,9 @@ func TestServiceAccountRendering(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			args := []string{"template", appName, path, "-s", "templates/serviceaccount.yaml"}
+			args := []string{"template", appName, path, "-s", "templates/serviceaccount.yaml",
+				"--set", "image.tag=latest",
+			}
 			if tt.values != "" {
 				args = append(args, strings.Split(tt.values, " ")...)
 			}


### PR DESCRIPTION
## Summary
- Removes the silent fallback to `appVersion` in the image helper
- Deployments without an explicit `image.tag` or `image.digest` now fail at render time with a clear error instead of silently using whatever `appVersion` is set to
- If both `image.tag` and `image.digest` are provided, digest takes precedence (unchanged behaviour)
- Bumps chart patch version