### PR TITLE
fix helm check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,7 +161,8 @@ k3d-setup:
 	k3d cluster create $(K3D_CLUSTER_NAME) -p "30083:30083@server:0" --api-port 127.0.0.1:6444
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o $(SERVICE_NAME) ./cmd/$(SERVICE_NAME)
 	docker build --no-cache -t localhost/$(SERVICE_NAME):latest -f Dockerfile.dev .
-	k3d image import localhost/$(SERVICE_NAME):latest -c $(K3D_CLUSTER_NAME)
+	docker pull postgres:alpine
+	k3d image import localhost/$(SERVICE_NAME):latest postgres:alpine -c $(K3D_CLUSTER_NAME)
 
 .PHONY: helm-integration-test-run
 helm-integration-test-run:

--- a/Makefile
+++ b/Makefile
@@ -161,8 +161,9 @@ k3d-setup:
 	k3d cluster create $(K3D_CLUSTER_NAME) -p "30083:30083@server:0" --api-port 127.0.0.1:6444
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o $(SERVICE_NAME) ./cmd/$(SERVICE_NAME)
 	docker build --no-cache -t localhost/$(SERVICE_NAME):latest -f Dockerfile.dev .
-	docker pull postgres:alpine
-	k3d image import localhost/$(SERVICE_NAME):latest postgres:alpine -c $(K3D_CLUSTER_NAME)
+	docker pull postgres:17-alpine
+	docker pull valkey/valkey:8-alpine
+	k3d image import localhost/$(SERVICE_NAME):latest postgres:17-alpine valkey/valkey:8-alpine -c $(K3D_CLUSTER_NAME)
 
 .PHONY: helm-integration-test-run
 helm-integration-test-run:

--- a/charts/session-manager/templates/migrate/job.yaml
+++ b/charts/session-manager/templates/migrate/job.yaml
@@ -33,22 +33,8 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      initContainers:
-        - name: wait-for-postgres
-          image: postgres:alpine
-          imagePullPolicy: IfNotPresent
-          env:
-            - name: PGPASSWORD
-              value: {{ .Values.config.database.password.value | quote }}
-          command:
-            - sh
-            - -c
-            - |
-              until psql -h {{ .Values.config.database.host.value }} -U {{ .Values.config.database.user.value }} -d {{ .Values.config.database.name }} -c "SELECT 1" >/dev/null 2>&1; do
-                echo "Waiting for PostgreSQL database {{ .Values.config.database.name }}..."
-                sleep 2
-              done
       {{- with .Values.extraInitContainers }}
+      initContainers:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:

--- a/charts/session-manager/templates/migrate/job.yaml
+++ b/charts/session-manager/templates/migrate/job.yaml
@@ -33,8 +33,8 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.extraInitContainers }}
       initContainers:
+      {{- with .Values.extraInitContainers }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:

--- a/charts/session-manager/templates/migrate/job.yaml
+++ b/charts/session-manager/templates/migrate/job.yaml
@@ -34,6 +34,20 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       initContainers:
+        - name: wait-for-postgres
+          image: postgres:alpine
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: PGPASSWORD
+              value: {{ .Values.config.database.password.value | quote }}
+          command:
+            - sh
+            - -c
+            - |
+              until psql -h {{ .Values.config.database.host.value }} -U {{ .Values.config.database.user.value }} -d {{ .Values.config.database.name }} -c "SELECT 1" >/dev/null 2>&1; do
+                echo "Waiting for PostgreSQL database {{ .Values.config.database.name }}..."
+                sleep 2
+              done
       {{- with .Values.extraInitContainers }}
         {{- toYaml . | nindent 8 }}
       {{- end }}


### PR DESCRIPTION
This PR aims at fixing the occasionally failing helm integration test check. k3d-setup now pre-pulls and imports postgres:17-alpine and valkey/valkey:8-alpine into the k3d cluster alongside the session-manager image, matching the exact versions used by the integration tests.
