### PR TITLE
feat: Session Manager/UI: on error redirect to "oops" page

### DIFF
--- a/api/session-manager.yaml
+++ b/api/session-manager.yaml
@@ -32,9 +32,21 @@ paths:
                   required: true
                   schema:
                       type: string
+                - name: error_uri
+                  in: query
+                  required: false
+                  description: |
+                      Base URL of the UI error page. When provided and an error occurs during the
+                      auth flow (including the callback), the session manager redirects to this URL
+                      with an appended errorCode query parameter instead of returning a JSON error body.
+                      Example: https://openkcm.com/#/tenantID/forbidden
+                  schema:
+                      type: string
             responses:
                 "302":
-                    description: Redirect to the OIDC provider with the login CSRF token cookie set.
+                    description: |
+                        On success: Redirect to the OIDC provider with the login CSRF token cookie set.
+                        On error (when error_uri is provided): Redirect to error_uri with errorCode parameter.
                     headers:
                         Location:
                             schema:
@@ -44,7 +56,7 @@ paths:
                             schema:
                                 type: string
                 default:
-                    description: Unexpected error
+                    description: Unexpected error (returned when error_uri is not provided)
                     content:
                         application/json:
                             schema:
@@ -168,6 +180,7 @@ paths:
                 "302":
                     description: |
                         Redirect to original request URI with session and CSRF cookies set.
+                        On error (when error_uri was provided during /sm/auth): Redirect to error_uri with errorCode parameter.
                         There is a limitation of OpenAPI that does not allow setting multiple cookies
                         with the strict handlers. Therefore, we do not define the Set-Cookie header
                         in the yaml spec. However, in the actual implementation both cookies are set.
@@ -177,13 +190,13 @@ paths:
                             schema:
                                 type: string
                 "403":
-                    description: Fingerprint mismatch
+                    description: Fingerprint mismatch (returned when error_uri is not available)
                     content:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/ErrorModel"
                 default:
-                    description: Unexpected error
+                    description: Unexpected error (returned when error_uri is not available)
                     content:
                         application/json:
                             schema:

--- a/internal/business/server/openapi.go
+++ b/internal/business/server/openapi.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/openkcm/common-sdk/pkg/csrf"
@@ -23,11 +24,12 @@ import (
 // sessionManager defines the interface for session management operations
 // used by the OpenAPI server.
 type sessionManager interface {
-	MakeAuthURI(ctx context.Context, tenantID, fingerprint, requestURI string) (string, string, error)
+	MakeAuthURI(ctx context.Context, tenantID, fingerprint, requestURI, errorURI string) (string, string, error)
 	FinaliseOIDCLogin(ctx context.Context, state, code, fingerprint string) (session.OIDCSessionData, error)
 	MakeSessionCookie(ctx context.Context, tenantID, sessionID string) (*http.Cookie, error)
 	MakeCSRFCookie(ctx context.Context, tenantID, csrfToken string) (*http.Cookie, error)
 	MakeLoginCSRFCookie(ctx context.Context, csrfToken string) (*http.Cookie, error)
+	LoadState(ctx context.Context, stateID string) (session.State, error)
 	Logout(ctx context.Context, sessionID, postLogoutRedirectURL string) (string, error)
 	BCLogout(ctx context.Context, logoutToken string) error
 }
@@ -72,17 +74,18 @@ func (s *openAPIServer) Auth(ctx context.Context, request openapi.AuthRequestObj
 	slogctx.Debug(ctx, "Auth() called", "tenantId", request.Params.TenantID, "requestUri", request.Params.RequestURI)
 	defer slogctx.Debug(ctx, "Auth() completed")
 
+	// Extract error_uri (optional, for backward compatibility with old UI that doesn't send it)
+	errorURI := ""
+	if request.Params.ErrorURI != nil {
+		errorURI = *request.Params.ErrorURI
+	}
+
 	if !s.isAllowedRedirectBaseURL(request.Params.RequestURI) {
 		err := fmt.Errorf("request URI does not match an allowed redirect base URL: %s", request.Params.RequestURI)
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "request URI does not match an allowed redirect base URL")
 		slogctx.Error(ctx, "Request URI does not match an allowed redirect base URL", "requestURI", request.Params.RequestURI)
-
-		body, status := s.toErrorModel(err)
-		return openapi.AuthdefaultJSONResponse{
-			Body:       body,
-			StatusCode: status,
-		}, nil
+		return s.authErrorResponse(errorURI, serviceerr.ErrInvalidRequest), nil
 	}
 
 	fingerprint, err := fingerprint.ExtractFingerprint(ctx)
@@ -90,35 +93,22 @@ func (s *openAPIServer) Auth(ctx context.Context, request openapi.AuthRequestObj
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "failed to extract fingerprint")
 		slogctx.Error(ctx, "Failed to extract fingerprint", "error", err)
-
-		body, status := s.toErrorModel(serviceerr.ErrUnknown)
-		return openapi.AuthdefaultJSONResponse{
-			Body:       body,
-			StatusCode: status,
-		}, nil
+		return s.authErrorResponse(errorURI, serviceerr.ErrUnknown), nil
 	}
 
-	url, csrfToken, err := s.sManager.MakeAuthURI(ctx, request.Params.TenantID, fingerprint, request.Params.RequestURI)
+	url, csrfToken, err := s.sManager.MakeAuthURI(ctx, request.Params.TenantID, fingerprint, request.Params.RequestURI, errorURI)
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "failed to build auth URI")
 		slogctx.Error(ctx, "Failed build auth URI", "error", err)
-
-		body, status := s.toErrorModel(err)
-		return openapi.AuthdefaultJSONResponse{
-			Body:       body,
-			StatusCode: status,
-		}, nil
+		return s.authErrorResponse(errorURI, err), nil
 	}
+
 	loginCsrfCookie, err := s.sManager.MakeLoginCSRFCookie(ctx, csrfToken)
 	if err != nil {
 		span.RecordError(err)
 		slogctx.Error(ctx, "Failed to make CSRF cookie", "error", err)
-		body, status := s.toErrorModel(err)
-		return openapi.AuthdefaultJSONResponse{
-			Body:       body,
-			StatusCode: status,
-		}, nil
+		return s.authErrorResponse(errorURI, err), nil
 	}
 
 	span.SetStatus(codes.Ok, "")
@@ -130,6 +120,20 @@ func (s *openAPIServer) Auth(ctx context.Context, request openapi.AuthRequestObj
 	}, nil
 }
 
+// authErrorResponse returns either a redirect to the error page or a JSON error response for the Auth endpoint.
+func (s *openAPIServer) authErrorResponse(errorURI string, err error) openapi.AuthResponseObject {
+	if redirectURL := s.buildErrorRedirectURL(errorURI, err); redirectURL != "" {
+		return openapi.Auth302Response{
+			Headers: openapi.Auth302ResponseHeaders{Location: redirectURL},
+		}
+	}
+	body, status := s.toErrorModel(err)
+	return openapi.AuthdefaultJSONResponse{
+		Body:       body,
+		StatusCode: status,
+	}
+}
+
 // Callback implements openapi.StrictServerInterface.
 func (s *openAPIServer) Callback(ctx context.Context, req openapi.CallbackRequestObject) (openapi.CallbackResponseObject, error) {
 	tracer := otel.GetTracerProvider()
@@ -139,17 +143,15 @@ func (s *openAPIServer) Callback(ctx context.Context, req openapi.CallbackReques
 	slogctx.Debug(ctx, "Callback() called", "state", req.Params.State)
 	defer slogctx.Debug(ctx, "Callback() completed")
 
+	// Try to load error_uri from state (best-effort, for error redirect)
+	errorURI := s.getErrorURIFromState(ctx, req.Params.State)
+
 	currentFingerprint, err := fingerprint.ExtractFingerprint(ctx)
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "failed extract fingerprint")
 		slogctx.Error(ctx, "Failed to extract fingerprint", "error", err)
-
-		body, status := s.toErrorModel(serviceerr.ErrUnknown)
-		return openapi.CallbackdefaultJSONResponse{
-			Body:       body,
-			StatusCode: status,
-		}, nil
+		return s.callbackErrorResponse(errorURI, serviceerr.ErrUnknown), nil
 	}
 
 	// Get the response writer from the context
@@ -158,40 +160,22 @@ func (s *openAPIServer) Callback(ctx context.Context, req openapi.CallbackReques
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "failed to get response writer from context")
 		slogctx.Error(ctx, "Failed to get response writer from context", "error", err)
-
-		body, status := s.toErrorModel(serviceerr.ErrUnknown)
-		return openapi.CallbackdefaultJSONResponse{
-			Body:       body,
-			StatusCode: status,
-		}, nil
+		return s.callbackErrorResponse(errorURI, serviceerr.ErrUnknown), nil
 	}
+
 	if !csrf.Validate(req.Params.UnderscoreUnderscoreHostLoginCSRF, req.Params.State, s.csrfSecret) {
 		err := serviceerr.ErrInvalidLoginCSRFToken
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
-		body, status := newBadRequest(err.Error())
-		return openapi.CallbackdefaultJSONResponse{
-			Body:       body,
-			StatusCode: status,
-		}, nil
+		return s.callbackErrorResponse(errorURI, err), nil
 	}
+
 	result, err := s.sManager.FinaliseOIDCLogin(ctx, req.Params.State, req.Params.Code, currentFingerprint)
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "failed to finalise OIDC login")
 		slogctx.Error(ctx, "Failed to finalise OIDC login", "error", err)
-
-		body, status := s.toErrorModel(err)
-		if status == 403 {
-			// return generic Unauthorized for 403 Forbidden to avoid leaking information on
-			// fingerprint mismatch in the original error body
-			body, status = s.toErrorModel(serviceerr.ErrUnauthorized)
-		}
-
-		return openapi.CallbackdefaultJSONResponse{
-			Body:       body,
-			StatusCode: status,
-		}, nil
+		return s.callbackFinaliseErrorResponse(errorURI, err), nil
 	}
 
 	// Session cookie
@@ -200,12 +184,7 @@ func (s *openAPIServer) Callback(ctx context.Context, req openapi.CallbackReques
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "failed to create session cookie")
 		slogctx.Error(ctx, "Failed to create session cookie", "error", err)
-
-		body, status := s.toErrorModel(serviceerr.ErrUnknown)
-		return openapi.CallbackdefaultJSONResponse{
-			Body:       body,
-			StatusCode: status,
-		}, nil
+		return s.callbackErrorResponse(result.ErrorURI, serviceerr.ErrUnknown), nil
 	}
 
 	// CSRF cookie
@@ -214,12 +193,7 @@ func (s *openAPIServer) Callback(ctx context.Context, req openapi.CallbackReques
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "failed to create CSRF cookie")
 		slogctx.Error(ctx, "Failed to create CSRF cookie", "error", err)
-
-		body, status := s.toErrorModel(serviceerr.ErrUnknown)
-		return openapi.CallbackdefaultJSONResponse{
-			Body:       body,
-			StatusCode: status,
-		}, nil
+		return s.callbackErrorResponse(result.ErrorURI, serviceerr.ErrUnknown), nil
 	}
 
 	// There is a limitation of OpenAPI that does not allow setting multiple cookies
@@ -236,6 +210,41 @@ func (s *openAPIServer) Callback(ctx context.Context, req openapi.CallbackReques
 			Location: result.RequestURI,
 		},
 	}, nil
+}
+
+// callbackErrorResponse returns either a redirect to the error page or a JSON error response.
+func (s *openAPIServer) callbackErrorResponse(errorURI string, err error) openapi.CallbackResponseObject {
+	if redirectURL := s.buildErrorRedirectURL(errorURI, err); redirectURL != "" {
+		return openapi.Callback302Response{
+			Headers: openapi.Callback302ResponseHeaders{Location: redirectURL},
+		}
+	}
+	body, status := s.toErrorModel(err)
+	return openapi.CallbackdefaultJSONResponse{
+		Body:       body,
+		StatusCode: status,
+	}
+}
+
+// callbackFinaliseErrorResponse handles the error case after FinaliseOIDCLogin fails,
+// masking fingerprint mismatch details when no error redirect is available.
+func (s *openAPIServer) callbackFinaliseErrorResponse(errorURI string, err error) openapi.CallbackResponseObject {
+	if redirectURL := s.buildErrorRedirectURL(errorURI, err); redirectURL != "" {
+		return openapi.Callback302Response{
+			Headers: openapi.Callback302ResponseHeaders{Location: redirectURL},
+		}
+	}
+
+	body, status := s.toErrorModel(err)
+	if status == 403 {
+		// return generic Unauthorized for 403 Forbidden to avoid leaking information on
+		// fingerprint mismatch in the original error body
+		body, status = s.toErrorModel(serviceerr.ErrUnauthorized)
+	}
+	return openapi.CallbackdefaultJSONResponse{
+		Body:       body,
+		StatusCode: status,
+	}
 }
 
 // Logout implements openapi.StrictServerInterface.
@@ -399,4 +408,57 @@ func newBadRequest(description string) (model openapi.ErrorModel, httpStatus int
 		Error:            string(serviceerr.CodeInvalidRequest),
 		ErrorDescription: &description,
 	}, http.StatusBadRequest
+}
+
+// buildErrorRedirectURL constructs a redirect URL to the UI error page with the error code.
+// Returns empty string if errorURI is not provided or not allowed (backward-compatible fallback to JSON).
+func (s *openAPIServer) buildErrorRedirectURL(errorURI string, err error) string {
+	if errorURI == "" {
+		return ""
+	}
+
+	// Validate error_uri against allowed redirect base URLs to prevent open redirect
+	if !s.isAllowedRedirectBaseURL(errorURI) {
+		return ""
+	}
+
+	var serviceErr *serviceerr.Error
+	if !errors.As(err, &serviceErr) {
+		serviceErr = serviceerr.ErrUnknown
+	}
+
+	errorCode := serviceErr.Err
+
+	// Log the original error so that it doesn't get lost when redirecting to the error page
+	slogctx.Error(context.Background(), "Redirecting to error page",
+		"errorCode", string(errorCode),
+		"errorURI", errorURI,
+		"originalError", err.Error(),
+	)
+
+	// Parse the error URI and add the error code as a query parameter
+	u, parseErr := url.Parse(errorURI)
+	if parseErr != nil {
+		return ""
+	}
+
+	q := u.Query()
+	q.Set("errorCode", string(errorCode))
+	q.Set("errorDescription", serviceErr.Description)
+	u.RawQuery = q.Encode()
+
+	return u.String()
+}
+
+// getErrorURIFromState loads the error_uri from state storage (best-effort).
+// Returns empty string if state cannot be loaded.
+func (s *openAPIServer) getErrorURIFromState(ctx context.Context, stateID string) string {
+	if s.sManager == nil {
+		return ""
+	}
+	state, err := s.sManager.LoadState(ctx, stateID)
+	if err != nil {
+		return ""
+	}
+	return state.ErrorURI
 }

--- a/internal/business/server/openapi_test.go
+++ b/internal/business/server/openapi_test.go
@@ -26,18 +26,19 @@ const (
 
 // mockSessionManager is a mock implementation of sessionManager interface for testing
 type mockSessionManager struct {
-	makeAuthURIFunc         func(ctx context.Context, tenantID, fingerprint, requestURI string) (string, string, error)
+	makeAuthURIFunc         func(ctx context.Context, tenantID, fingerprint, requestURI, errorURI string) (string, string, error)
 	finaliseOIDCLoginFunc   func(ctx context.Context, state, code, fingerprint string) (session.OIDCSessionData, error)
 	makeSessionCookieFunc   func(ctx context.Context, tenantID, sessionID string) (*http.Cookie, error)
 	makeCSRFCookieFunc      func(ctx context.Context, tenantID, csrfToken string) (*http.Cookie, error)
 	makeLoginCSRFCookieFunc func(ctx context.Context, csrfToken string) (*http.Cookie, error)
+	loadStateFunc           func(ctx context.Context, stateID string) (session.State, error)
 	logoutFunc              func(ctx context.Context, sessionID, postLogoutRedirectURL string) (string, error)
 	bcLogoutFunc            func(ctx context.Context, logoutToken string) error
 }
 
-func (m *mockSessionManager) MakeAuthURI(ctx context.Context, tenantID, fp, requestURI string) (string, string, error) {
+func (m *mockSessionManager) MakeAuthURI(ctx context.Context, tenantID, fp, requestURI, errorURI string) (string, string, error) {
 	if m.makeAuthURIFunc != nil {
-		return m.makeAuthURIFunc(ctx, tenantID, fp, requestURI)
+		return m.makeAuthURIFunc(ctx, tenantID, fp, requestURI, errorURI)
 	}
 	return "", "", errors.New("not implemented")
 }
@@ -68,6 +69,13 @@ func (m *mockSessionManager) MakeLoginCSRFCookie(ctx context.Context, csrfToken 
 		return m.makeLoginCSRFCookieFunc(ctx, csrfToken)
 	}
 	return nil, errors.New("not implemented")
+}
+
+func (m *mockSessionManager) LoadState(ctx context.Context, stateID string) (session.State, error) {
+	if m.loadStateFunc != nil {
+		return m.loadStateFunc(ctx, stateID)
+	}
+	return session.State{}, errors.New("not implemented")
 }
 
 func (m *mockSessionManager) Logout(ctx context.Context, sessionID, postLogoutRedirectURL string) (string, error) {
@@ -103,7 +111,9 @@ func TestOpenAPIServer_Auth_ContextCanceled(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
 	server := newOpenAPIServer(nil, nil, "", "", []string{allowedBaseURL})
-	req := openapi.AuthRequestObject{}
+	req := openapi.AuthRequestObject{
+		Params: openapi.AuthParams{RequestURI: allowedBaseURL + "/page"},
+	}
 	resp, err := server.Auth(ctx, req)
 	assert.NoError(t, err)
 
@@ -117,7 +127,9 @@ func TestOpenAPIServer_Auth_ContextCanceled(t *testing.T) {
 func TestOpenAPIServer_Auth_ExtractFingerprint_Failed(t *testing.T) {
 	ctx := t.Context()
 	server := newOpenAPIServer(nil, nil, "", "", []string{allowedBaseURL})
-	req := openapi.AuthRequestObject{}
+	req := openapi.AuthRequestObject{
+		Params: openapi.AuthParams{RequestURI: allowedBaseURL + "/page"},
+	}
 	resp, err := server.Auth(ctx, req)
 	assert.NoError(t, err)
 
@@ -131,12 +143,14 @@ func TestOpenAPIServer_Auth_ExtractFingerprint_Failed(t *testing.T) {
 func TestOpenAPIServer_Auth_MakeAuthURI_Failed(t *testing.T) {
 	ctx := fingerprint.WithFingerprint(t.Context(), "")
 	mock := &mockSessionManager{
-		makeAuthURIFunc: func(ctx context.Context, tenantID string, fingerprint string, requestURI string) (string, string, error) {
+		makeAuthURIFunc: func(ctx context.Context, tenantID string, fingerprint string, requestURI string, errorURI string) (string, string, error) {
 			return "", "", errors.New("error")
 		},
 	}
 	server := newOpenAPIServer(mock, nil, "", "", []string{allowedBaseURL})
-	req := openapi.AuthRequestObject{}
+	req := openapi.AuthRequestObject{
+		Params: openapi.AuthParams{RequestURI: allowedBaseURL + "/page"},
+	}
 	resp, err := server.Auth(ctx, req)
 	assert.NoError(t, err)
 
@@ -150,7 +164,7 @@ func TestOpenAPIServer_Auth_MakeAuthURI_Failed(t *testing.T) {
 func TestOpenAPIServer_Auth_MakeCSRFCookie_Failed(t *testing.T) {
 	ctx := fingerprint.WithFingerprint(t.Context(), "")
 	mock := &mockSessionManager{
-		makeAuthURIFunc: func(ctx context.Context, tenantID string, fingerprint string, requestURI string) (string, string, error) {
+		makeAuthURIFunc: func(ctx context.Context, tenantID string, fingerprint string, requestURI string, errorURI string) (string, string, error) {
 			return "https://example.com/redirect", "token", nil
 		},
 		makeLoginCSRFCookieFunc: func(ctx context.Context, csrfToken string) (*http.Cookie, error) {
@@ -158,7 +172,9 @@ func TestOpenAPIServer_Auth_MakeCSRFCookie_Failed(t *testing.T) {
 		},
 	}
 	server := newOpenAPIServer(mock, nil, "", "", []string{allowedBaseURL})
-	req := openapi.AuthRequestObject{}
+	req := openapi.AuthRequestObject{
+		Params: openapi.AuthParams{RequestURI: allowedBaseURL + "/page"},
+	}
 	resp, err := server.Auth(ctx, req)
 	assert.NoError(t, err)
 	assert.IsType(t, openapi.AuthdefaultJSONResponse{}, resp)
@@ -171,7 +187,7 @@ func TestOpenAPIServer_Auth_MakeCSRFCookie_Failed(t *testing.T) {
 func TestOpenAPIServer_Auth_MakeAuthURI_Success(t *testing.T) {
 	ctx := fingerprint.WithFingerprint(t.Context(), "")
 	mock := &mockSessionManager{
-		makeAuthURIFunc: func(ctx context.Context, tenantID string, fingerprint string, requestURI string) (string, string, error) {
+		makeAuthURIFunc: func(ctx context.Context, tenantID string, fingerprint string, requestURI string, errorURI string) (string, string, error) {
 			return "https://example.com/redirect", "token", nil
 		},
 		makeLoginCSRFCookieFunc: func(ctx context.Context, csrfToken string) (*http.Cookie, error) {
@@ -366,7 +382,7 @@ func TestOpenAPIServer_Callback_InvalidCsrfToken_Failed(t *testing.T) {
 		assert.IsType(t, openapi.CallbackdefaultJSONResponse{}, resp)
 
 		r, _ := resp.(openapi.CallbackdefaultJSONResponse)
-		assert.Equal(t, string(serviceerr.CodeInvalidRequest), r.Body.Error)
+		assert.Equal(t, string(serviceerr.CodeInvalidLoginCSRFToken), r.Body.Error)
 		assert.Equal(t, http.StatusBadRequest, r.StatusCode)
 	})
 }
@@ -628,7 +644,7 @@ func TestOpenAPIServer_ToErrorModel(t *testing.T) {
 				name:       "invalid CSRF token error",
 				err:        serviceerr.ErrInvalidCSRFToken,
 				wantCode:   serviceerr.CodeInvalidCSRFToken,
-				wantStatus: http.StatusInternalServerError, // Default status since not in switch
+				wantStatus: http.StatusBadRequest,
 			},
 		}
 
@@ -763,6 +779,140 @@ func TestOpenAPIServer_Logout_Success(t *testing.T) {
 			assert.Equal(t, -1, cookie.MaxAge)
 			assert.Empty(t, cookie.Value)
 		}
+	})
+}
+
+func TestOpenAPIServer_BuildErrorRedirectURL(t *testing.T) {
+	server := newOpenAPIServer(nil, nil, "", "", []string{allowedBaseURL})
+
+	t.Run("returns empty when errorURI is empty", func(t *testing.T) {
+		result := server.buildErrorRedirectURL("", serviceerr.ErrNotFound)
+		assert.Empty(t, result)
+	})
+
+	t.Run("returns empty when errorURI is not in allowed list", func(t *testing.T) {
+		result := server.buildErrorRedirectURL("https://evil.com/error", serviceerr.ErrNotFound)
+		assert.Empty(t, result)
+	})
+
+	t.Run("returns redirect URL with error code for allowed errorURI", func(t *testing.T) {
+		result := server.buildErrorRedirectURL("https://app.example.com/error", serviceerr.ErrNotFound)
+		assert.Contains(t, result, "errorCode=not_found")
+		assert.Contains(t, result, "errorDescription=not+found")
+	})
+
+	t.Run("preserves existing query params and adds errorCode", func(t *testing.T) {
+		result := server.buildErrorRedirectURL("https://app.example.com/error?tenant=x", serviceerr.ErrStateExpired)
+		assert.Contains(t, result, "errorCode=state_expired")
+		assert.Contains(t, result, "tenant=x")
+		assert.Contains(t, result, "https://app.example.com/error?")
+	})
+
+	t.Run("maps unknown error to unknown", func(t *testing.T) {
+		result := server.buildErrorRedirectURL("https://app.example.com/error", errors.New("random"))
+		assert.Contains(t, result, "errorCode=unknown")
+		assert.Contains(t, result, "errorDescription=unknown+error")
+	})
+
+	t.Run("maps fingerprint mismatch to fingerprint_mismatch", func(t *testing.T) {
+		result := server.buildErrorRedirectURL("https://app.example.com/error", serviceerr.ErrFingerprintMismatch)
+		assert.Contains(t, result, "errorCode=fingerprint_mismatch")
+		assert.Contains(t, result, "errorDescription=fingerprint+mismatch")
+	})
+}
+
+func TestOpenAPIServer_GetErrorURIFromState(t *testing.T) {
+	t.Run("returns empty when sManager is nil", func(t *testing.T) {
+		server := newOpenAPIServer(nil, nil, "", "", []string{allowedBaseURL})
+		result := server.getErrorURIFromState(context.Background(), "some-state")
+		assert.Empty(t, result)
+	})
+
+	t.Run("returns empty when LoadState fails", func(t *testing.T) {
+		mock := &mockSessionManager{
+			loadStateFunc: func(ctx context.Context, stateID string) (session.State, error) {
+				return session.State{}, errors.New("not found")
+			},
+		}
+		server := newOpenAPIServer(mock, nil, "", "", []string{allowedBaseURL})
+		result := server.getErrorURIFromState(context.Background(), "some-state")
+		assert.Empty(t, result)
+	})
+
+	t.Run("returns errorURI from state", func(t *testing.T) {
+		mock := &mockSessionManager{
+			loadStateFunc: func(ctx context.Context, stateID string) (session.State, error) {
+				return session.State{ErrorURI: "https://app.example.com/error"}, nil
+			},
+		}
+		server := newOpenAPIServer(mock, nil, "", "", []string{allowedBaseURL})
+		result := server.getErrorURIFromState(context.Background(), "some-state")
+		assert.Equal(t, "https://app.example.com/error", result)
+	})
+}
+
+func TestOpenAPIServer_AuthErrorResponse(t *testing.T) {
+	t.Run("returns JSON when no errorURI", func(t *testing.T) {
+		server := newOpenAPIServer(nil, nil, "", "", []string{allowedBaseURL})
+		resp := server.authErrorResponse("", serviceerr.ErrUnknown)
+		assert.IsType(t, openapi.AuthdefaultJSONResponse{}, resp)
+	})
+
+	t.Run("returns redirect when errorURI is valid", func(t *testing.T) {
+		server := newOpenAPIServer(nil, nil, "", "", []string{allowedBaseURL})
+		resp := server.authErrorResponse("https://app.example.com/error", serviceerr.ErrNotFound)
+		assert.IsType(t, openapi.Auth302Response{}, resp)
+		r, ok := resp.(openapi.Auth302Response)
+		require.True(t, ok)
+		assert.Contains(t, r.Headers.Location, "errorCode=not_found")
+	})
+}
+
+func TestOpenAPIServer_CallbackErrorResponse(t *testing.T) {
+	t.Run("returns JSON when no errorURI", func(t *testing.T) {
+		server := newOpenAPIServer(nil, nil, "", "", []string{allowedBaseURL})
+		resp := server.callbackErrorResponse("", serviceerr.ErrUnknown)
+		assert.IsType(t, openapi.CallbackdefaultJSONResponse{}, resp)
+	})
+
+	t.Run("returns redirect when errorURI is valid", func(t *testing.T) {
+		server := newOpenAPIServer(nil, nil, "", "", []string{allowedBaseURL})
+		resp := server.callbackErrorResponse("https://app.example.com/error", serviceerr.ErrStateExpired)
+		assert.IsType(t, openapi.Callback302Response{}, resp)
+		r, ok := resp.(openapi.Callback302Response)
+		require.True(t, ok)
+		assert.Contains(t, r.Headers.Location, "errorCode=state_expired")
+	})
+}
+
+func TestOpenAPIServer_CallbackFinaliseErrorResponse(t *testing.T) {
+	t.Run("returns redirect when errorURI is valid", func(t *testing.T) {
+		server := newOpenAPIServer(nil, nil, "", "", []string{allowedBaseURL})
+		resp := server.callbackFinaliseErrorResponse("https://app.example.com/error", serviceerr.ErrFingerprintMismatch)
+		assert.IsType(t, openapi.Callback302Response{}, resp)
+		r, ok := resp.(openapi.Callback302Response)
+		require.True(t, ok)
+		assert.Contains(t, r.Headers.Location, "errorCode=fingerprint_mismatch")
+	})
+
+	t.Run("masks 403 to unauthorized when no errorURI", func(t *testing.T) {
+		server := newOpenAPIServer(nil, nil, "", "", []string{allowedBaseURL})
+		resp := server.callbackFinaliseErrorResponse("", serviceerr.ErrFingerprintMismatch)
+		assert.IsType(t, openapi.CallbackdefaultJSONResponse{}, resp)
+		r, ok := resp.(openapi.CallbackdefaultJSONResponse)
+		require.True(t, ok)
+		assert.Equal(t, string(serviceerr.CodeUnauthorizedClient), r.Body.Error)
+		assert.Equal(t, http.StatusUnauthorized, r.StatusCode)
+	})
+
+	t.Run("returns original error when not 403 and no errorURI", func(t *testing.T) {
+		server := newOpenAPIServer(nil, nil, "", "", []string{allowedBaseURL})
+		resp := server.callbackFinaliseErrorResponse("", serviceerr.ErrStateExpired)
+		assert.IsType(t, openapi.CallbackdefaultJSONResponse{}, resp)
+		r, ok := resp.(openapi.CallbackdefaultJSONResponse)
+		require.True(t, ok)
+		assert.Equal(t, string(serviceerr.CodeStateExpired), r.Body.Error)
+		assert.Equal(t, http.StatusGone, r.StatusCode)
 	})
 }
 

--- a/internal/openapi/server.go
+++ b/internal/openapi/server.go
@@ -25,6 +25,12 @@ type ErrorModel struct {
 type AuthParams struct {
 	TenantID   string `form:"tenant_id" json:"tenant_id"`
 	RequestURI string `form:"request_uri" json:"request_uri"`
+
+	// ErrorURI Base URL of the UI error page. When provided and an error occurs during the
+	// auth flow (including the callback), the session manager redirects to this URL
+	// with an appended errorCode query parameter instead of returning a JSON error body.
+	// Example: https://ui.cmk.sap/#/tenantID/forbidden
+	ErrorURI *string `form:"error_uri,omitempty" json:"error_uri,omitempty"`
 }
 
 // BclogoutFormdataBody defines parameters for Bclogout.
@@ -110,6 +116,14 @@ func (siw *ServerInterfaceWrapper) Auth(w http.ResponseWriter, r *http.Request) 
 	err = runtime.BindQueryParameter("form", true, true, "request_uri", r.URL.Query(), &params.RequestURI)
 	if err != nil {
 		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "request_uri", Err: err})
+		return
+	}
+
+	// ------------- Optional query parameter "error_uri" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "error_uri", r.URL.Query(), &params.ErrorURI)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "error_uri", Err: err})
 		return
 	}
 

--- a/internal/serviceerr/errors.go
+++ b/internal/serviceerr/errors.go
@@ -139,6 +139,10 @@ func (e Error) HTTPStatus() int {
 		return http.StatusUnauthorized
 	case CodeEndSessionNotSupported:
 		return http.StatusPreconditionFailed
+	case CodeInvalidCSRFToken:
+		return http.StatusBadRequest
+	case CodeInvalidLoginCSRFToken:
+		return http.StatusBadRequest
 	default:
 		return http.StatusInternalServerError
 	}

--- a/internal/serviceerr/errors_test.go
+++ b/internal/serviceerr/errors_test.go
@@ -142,9 +142,9 @@ func TestError_HTTPStatus(t *testing.T) {
 			expectedHTTPStatus: http.StatusPreconditionFailed,
 		},
 		{
-			name:               "CodeInvalidCSRFToken returns InternalServerError by default",
+			name:               "CodeInvalidCSRFToken returns BadRequest",
 			code:               serviceerr.CodeInvalidCSRFToken,
-			expectedHTTPStatus: http.StatusInternalServerError,
+			expectedHTTPStatus: http.StatusBadRequest,
 		},
 		{
 			name:               "CodeInvalidAtHashToken returns Unauthorized",

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -120,7 +120,7 @@ func NewManager(
 }
 
 // MakeAuthURI returns an OIDC authentication URI.
-func (m *Manager) MakeAuthURI(ctx context.Context, tenantID, fingerprint, requestURI string) (string, string, error) {
+func (m *Manager) MakeAuthURI(ctx context.Context, tenantID, fingerprint, requestURI, errorURI string) (string, string, error) {
 	mapping, err := m.trustRepo.Get(ctx, tenantID)
 	if err != nil {
 		return "", "", fmt.Errorf("getting trust mapping: %w", err)
@@ -145,6 +145,7 @@ func (m *Manager) MakeAuthURI(ctx context.Context, tenantID, fingerprint, reques
 		Fingerprint:    fingerprint,
 		PKCEVerifier:   pkce.Verifier,
 		RequestURI:     requestURI,
+		ErrorURI:       errorURI,
 		Expiry:         time.Now().Add(m.sessionDuration),
 		LoginCSRFToken: csrfToken,
 	}
@@ -372,6 +373,7 @@ func (m *Manager) FinaliseOIDCLogin(ctx context.Context, stateID, code, fingerpr
 		TenantID:   state.TenantID,
 		CSRFToken:  csrfToken,
 		RequestURI: state.RequestURI,
+		ErrorURI:   state.ErrorURI,
 	}, nil
 }
 

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -150,7 +150,7 @@ func TestManager_Auth(t *testing.T) {
 				session.WithAllowHttpScheme(true),
 			)
 			require.NoError(t, err)
-			got, _, err := m.MakeAuthURI(t.Context(), tt.tenantID, tt.fingerprint, tt.requestURI)
+			got, _, err := m.MakeAuthURI(t.Context(), tt.tenantID, tt.fingerprint, tt.requestURI, "")
 
 			if !tt.errAssert(t, err, fmt.Sprintf("Manager.Auth() error = %v", err)) || err != nil {
 				return

--- a/internal/session/model.go
+++ b/internal/session/model.go
@@ -11,6 +11,7 @@ type State struct {
 	Fingerprint    string    // Fingerprint to bind the login to a specific client
 	PKCEVerifier   string    // PKCE verifier to validate the PKCE challenge
 	RequestURI     string    // Request URI for the eventual redirect
+	ErrorURI       string    // Error URI for redirecting to UI error page on failure (optional)
 	Expiry         time.Time // Expiry time of the login process
 	LoginCSRFToken string    // CSRF token to prevent CSRF attacks
 }
@@ -46,6 +47,7 @@ type OIDCSessionData struct {
 	TenantID   string
 	CSRFToken  string
 	RequestURI string
+	ErrorURI   string // Error URI for redirecting to UI error page on failure (optional)
 }
 
 // tokenResponse represents the response from the token endpoint


### PR DESCRIPTION
When the error occures in session manager, instead of showing just the mysterious json and returning 400, redirect to the (existing or specially designed) error page showing error and description.