### PR TITLE
fix: config map name in chart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,9 +161,7 @@ k3d-setup:
 	k3d cluster create $(K3D_CLUSTER_NAME) -p "30083:30083@server:0" --api-port 127.0.0.1:6444
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o $(SERVICE_NAME) ./cmd/$(SERVICE_NAME)
 	docker build --no-cache -t localhost/$(SERVICE_NAME):latest -f Dockerfile.dev .
-	docker pull postgres:17-alpine
-	docker pull valkey/valkey:8-alpine
-	k3d image import localhost/$(SERVICE_NAME):latest postgres:17-alpine valkey/valkey:8-alpine -c $(K3D_CLUSTER_NAME)
+	k3d image import localhost/$(SERVICE_NAME):latest -c $(K3D_CLUSTER_NAME)
 
 .PHONY: helm-integration-test-run
 helm-integration-test-run:

--- a/charts/session-manager/Chart.yaml
+++ b/charts/session-manager/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.9.5
+version: 0.9.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/session-manager/templates/configmap.yaml
+++ b/charts/session-manager/templates/configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "session-manager.name" . }}-config
+  name: {{ include "session-manager.fullname" . }}-config
   labels:
     {{- include "session-manager.labels" . | nindent 4 }}
   annotations:

--- a/charts/session-manager/templates/housekeeper/deployment.yaml
+++ b/charts/session-manager/templates/housekeeper/deployment.yaml
@@ -66,18 +66,18 @@ spec:
               memory: 64Mi
           {{- end }}
           volumeMounts:
-            - name: {{ include "session-manager.name" . }}-config-volume
+            - name: {{ include "session-manager.fullname" . }}-config-volume
               mountPath: /etc/{{ include "session-manager.name" . }}
               readOnly: true
           {{- with .Values.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
       volumes:
-        - name: {{ include "session-manager.name" . }}-config-volume
+        - name: {{ include "session-manager.fullname" . }}-config-volume
           projected:
             sources:
               - configMap:
-                  name: {{ include "session-manager.name" . }}-config
+                  name: {{ include "session-manager.fullname" . }}-config
       {{- with .Values.extraVolumes }}
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/session-manager/templates/migrate/job.yaml
+++ b/charts/session-manager/templates/migrate/job.yaml
@@ -54,18 +54,18 @@ spec:
           args: [ "migrate" ]
           env: []
           volumeMounts:
-            - name: {{ include "session-manager.name" . }}-config-volume
+            - name: {{ include "session-manager.fullname" . }}-config-volume
               mountPath: /etc/{{ include "session-manager.name" . }}
               readOnly: true
           {{- with .Values.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
       volumes:
-        - name: {{ include "session-manager.name" . }}-config-volume
+        - name: {{ include "session-manager.fullname" . }}-config-volume
           projected:
             sources:
               - configMap:
-                  name: {{ include "session-manager.name" . }}-config
+                  name: {{ include "session-manager.fullname" . }}-config
       {{- with .Values.extraVolumes }}
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/session-manager/templates/session-manager/deployment.yaml
+++ b/charts/session-manager/templates/session-manager/deployment.yaml
@@ -93,18 +93,18 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           volumeMounts:
-            - name: {{ include "session-manager.name" . }}-config-volume
+            - name: {{ include "session-manager.fullname" . }}-config-volume
               mountPath: /etc/{{ include "session-manager.name" . }}
               readOnly: true
           {{- with .Values.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
       volumes:
-        - name: {{ include "session-manager.name" . }}-config-volume
+        - name: {{ include "session-manager.fullname" . }}-config-volume
           projected:
             sources:
               - configMap:
-                  name: {{ include "session-manager.name" . }}-config
+                  name: {{ include "session-manager.fullname" . }}-config
       {{- with .Values.extraVolumes }}
         {{- toYaml . | nindent 8 }}
       {{- end }}


### PR DESCRIPTION
**Problem**: The migrate job couldn't find the ConfigMap `session-manager-config` because the ConfigMap was using `session-manager.name` (which returns just `session-manager`) instead of `session-manager.fullname` (which includes the release name).

**Root Cause**: The ConfigMap and its references used `session-manager.name` which doesn't include the Helm release name, violating release isolation. Multiple releases in the same namespace would have shared the same ConfigMap, and the hook deletion policy could delete another release's ConfigMap.

**Fix**: Changed all ConfigMap naming and references from `session-manager.name` to `session-manager.fullname` in:
- `charts/session-manager/templates/configmap.yaml` (line 4)
- `charts/session-manager/templates/migrate/job.yaml` (lines 57, 64, 68)
- `charts/session-manager/templates/session-manager/deployment.yaml` (lines 96, 103, 107)
- `charts/session-manager/templates/housekeeper/deployment.yaml` (lines 69, 76, 80)

The `mountPath` was kept as `session-manager.name` since the application expects config at `/etc/session-manager/`.

**Result**: ConfigMap now has release-specific name (e.g., `test-release-session-manager-config`) and all references match correctly. The migrate job completes successfully.