### PR TITLE
fix: close JWKS HTTP response body in getProviderKeySet

### DIFF
--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -199,6 +199,7 @@ func (m *Manager) getProviderKeySet(ctx context.Context, oidcConf *oidc.Configur
 	if err != nil {
 		return nil, fmt.Errorf("executing an http request: %w", err)
 	}
+	defer resp.Body.Close()
 
 	err = json.NewDecoder(resp.Body).Decode(&keySet)
 	if err != nil {


### PR DESCRIPTION
The response body was never closed after decoding, leaking file descriptors and connection pool resources on every JWKS fetch.

<!-- Format of PR Title: <category>: <description>
Possible values:
- category:       breaking|feat|doc|build|chore|ci|docs|fix|perf|refactor|revert|style|test
- description:   <short description of the PR>

Following the conventional commits: https://www.conventionalcommits.org
-->

**What this PR does / why we need it**:
``` Detailed description of PR; If no description, remove the block.

```

**Special notes for your reviewer**:
``` If no notes, remove the block.

```

**Release note**:
``` Release notes; If no release note is required, just write "NONE" within the block.

```
