### PR TITLE
fix: stop ticker on housekeeper shutdown

### DIFF
--- a/internal/business/housekeeper.go
+++ b/internal/business/housekeeper.go
@@ -40,7 +40,8 @@ func HousekeeperMain(ctx context.Context, cfg *config.Config) error {
 	defer closeFn()
 
 	// Start the housekeeper loop
-	tick := time.Tick(cfg.Housekeeper.TriggerInterval)
+	ticker := time.NewTicker(cfg.Housekeeper.TriggerInterval)
+	defer ticker.Stop()
 	refreshTriggerInterval := cfg.Housekeeper.TokenRefreshTriggerInterval
 	concurrencyLimit := cfg.Housekeeper.ConcurrencyLimit
 	for {
@@ -50,7 +51,7 @@ func HousekeeperMain(ctx context.Context, cfg *config.Config) error {
 		}
 
 		select {
-		case <-tick:
+		case <-ticker.C:
 			continue
 		case <-c.Done():
 			return nil


### PR DESCRIPTION
time.Tick() returns a channel backed by a ticker that is never stopped. Replacing with time.NewTicker() and defer ticker.Stop() ensures the underlying timer is released when the context is cancelled.

<!-- Format of PR Title: <category>: <description>
Possible values:
- category:       breaking|feat|doc|build|chore|ci|docs|fix|perf|refactor|revert|style|test
- description:   <short description of the PR>

Following the conventional commits: https://www.conventionalcommits.org
-->

**What this PR does / why we need it**:
``` Detailed description of PR; If no description, remove the block.

```

**Special notes for your reviewer**:
``` If no notes, remove the block.

```

**Release note**:
``` Release notes; If no release note is required, just write "NONE" within the block.

```
