### PR TITLE
fix: use context.AfterFunc to stop ttlcache on shutdown

### DIFF
--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -105,10 +105,7 @@ func NewManager(
 
 	m.wkocCache = ttlcache.New(ttlcache.WithTTL[string, *oidc.Configuration](defaultWKOCCacheExpiration))
 	go m.wkocCache.Start()
-	go func(ctx context.Context) {
-		<-ctx.Done()
-		m.wkocCache.Stop()
-	}(ctx)
+	context.AfterFunc(ctx, m.wkocCache.Stop)
 
 	return m, nil
 }

--- a/modules/grpc/session/server.go
+++ b/modules/grpc/session/server.go
@@ -68,10 +68,7 @@ func NewServer(
 
 	s.introspectionCache = ttlcache.New(ttlcache.WithTTL[string, oidc.Introspection](defaultIntrospectionCacheExpiration))
 	go s.introspectionCache.Start()
-	go func(ctx context.Context) {
-		<-ctx.Done()
-		s.introspectionCache.Stop()
-	}(ctx)
+	context.AfterFunc(ctx, s.introspectionCache.Stop)
 
 	return s
 }


### PR DESCRIPTION
The stop goroutine pattern used a manual goroutine to call Stop() when the context was cancelled. If the context was already cancelled before Start() ran, Stop() would block indefinitely waiting on stopCh with no reader.

Replace with context.AfterFunc which handles the already-cancelled case correctly. Applies to wkocCache in session.Manager and introspectionCache in grpc.SessionServer.

<!-- Format of PR Title: <category>: <description>
Possible values:
- category:       breaking|feat|doc|build|chore|ci|docs|fix|perf|refactor|revert|style|test
- description:   <short description of the PR>

Following the conventional commits: https://www.conventionalcommits.org
-->

**What this PR does / why we need it**:
``` Detailed description of PR; If no description, remove the block.

```

**Special notes for your reviewer**:
``` If no notes, remove the block.

```

**Release note**:
``` Release notes; If no release note is required, just write "NONE" within the block.

```
