### PR TITLE
feat: add allowTLSRenegotiationOnce

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -259,6 +259,11 @@ type ClientAuth struct {
 	MTLS *commoncfg.MTLS `yaml:"mTLS"`
 	// ClientSecret contains the client secret source reference when Type is set to "clientSecret".
 	ClientSecret commoncfg.SourceRef `yaml:"clientSecret"`
+	// AllowTLSRenegotiationOnce enables TLS renegotiation as a client.
+	// When true, sets tls.Config.Renegotiation to tls.RenegotiateOnceAsClient,
+	// allowing exactly one renegotiation per connection. This may be required
+	// by some identity providers. Default is false (tls.RenegotiateNever).
+	AllowTLSRenegotiationOnce bool `yaml:"allowTLSRenegotiationOnce"`
 
 	// Deprecated: ClientID is no longer used in the application code, but is still required in the config
 	// to backfill existing database entries during migration.

--- a/modules/credentials/oauth2/module.go
+++ b/modules/credentials/oauth2/module.go
@@ -5,6 +5,7 @@
 package oauth2
 
 import (
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -60,6 +61,9 @@ func (m *Module) Provision(ctx *sessionmanager.Context) error {
 		tlsConfig, err := commoncfg.LoadMTLSConfig(clientAuth.MTLS)
 		if err != nil {
 			return fmt.Errorf("loading mTLS config: %w", err)
+		}
+		if clientAuth.AllowTLSRenegotiationOnce {
+			tlsConfig.Renegotiation = tls.RenegotiateOnceAsClient
 		}
 		m.builder = func(clientID string) credentials.TransportCredentials {
 			return credentials.NewTLS(clientID, tlsConfig)


### PR DESCRIPTION
AllowTLSRenegotiationOnce enables TLS renegotiation as a client. When true, sets tls.Config.Renegotiation to tls.RenegotiateOnceAsClient, allowing exactly one renegotiation per connection. This is required by some identity providers. Default is false (tls.RenegotiateNever).